### PR TITLE
feat: Add canonical W3C/Dublin Core URIs for field detection

### DIFF
--- a/src/linkml_reference_validator/field_detection.py
+++ b/src/linkml_reference_validator/field_detection.py
@@ -1,0 +1,467 @@
+"""Field detection for reference validation.
+
+This module provides the logic for identifying which schema slots represent
+excerpt fields, reference fields, and title fields. This is separate from
+the validation logic itself.
+
+Schema authors can use ANY supported URI in EITHER `slot_uri` OR `implements`.
+All combinations work:
+
+Excerpt fields:
+    - Canonical: oa:exact (http://www.w3.org/ns/oa#exact)
+    - Legacy: linkml:excerpt (https://w3id.org/linkml/excerpt)
+
+Reference fields:
+    - Canonical: dcterms:references (http://purl.org/dc/terms/references)
+    - Legacy: linkml:authoritative_reference
+
+Title fields:
+    - dcterms:title (http://purl.org/dc/terms/title)
+
+Example schema usage (all equivalent for excerpt):
+    slot_uri: oa:exact
+    implements: [oa:exact]
+    implements: [linkml:excerpt]
+    slot_uri: linkml:excerpt
+
+Note: Users may declare custom prefixes (e.g., `dc:` instead of `dcterms:`).
+The detection functions accept an optional prefix_map to expand CURIEs to
+full URIs before matching.
+"""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable, Optional, Protocol
+
+if TYPE_CHECKING:
+    from curies import Converter
+
+
+# =============================================================================
+# URI Constants
+# =============================================================================
+
+@dataclass(frozen=True)
+class ExcerptURIs:
+    """URIs that identify a slot as an excerpt/supporting text field.
+
+    Canonical URI is from W3C Web Annotation vocabulary.
+    Legacy URIs are supported for backwards compatibility.
+
+    Examples:
+        >>> ExcerptURIs.CANONICAL
+        'http://www.w3.org/ns/oa#exact'
+        >>> ExcerptURIs.is_excerpt_uri("oa:exact")
+        True
+        >>> ExcerptURIs.is_excerpt_uri("linkml:excerpt")
+        True
+    """
+
+    # Canonical: W3C Web Annotation - "copy of the text which is being selected"
+    CANONICAL: str = "http://www.w3.org/ns/oa#exact"
+    CANONICAL_PREFIXED: str = "oa:exact"
+
+    # Legacy: LinkML excerpt
+    LEGACY_LINKML: str = "https://w3id.org/linkml/excerpt"
+    LEGACY_LINKML_PREFIXED: str = "linkml:excerpt"
+
+    # Additional patterns to match (substrings)
+    MATCH_PATTERNS: tuple[str, ...] = (
+        "oa:exact",
+        "oa#exact",
+        "excerpt",
+        "supporting_text",
+    )
+
+    @classmethod
+    def is_excerpt_uri(cls, uri: str) -> bool:
+        """Check if a URI identifies an excerpt field.
+
+        Args:
+            uri: URI string to check (can be full or prefixed)
+
+        Returns:
+            True if the URI matches any known excerpt pattern
+
+        Examples:
+            >>> ExcerptURIs.is_excerpt_uri("http://www.w3.org/ns/oa#exact")
+            True
+            >>> ExcerptURIs.is_excerpt_uri("oa:exact")
+            True
+            >>> ExcerptURIs.is_excerpt_uri("linkml:excerpt")
+            True
+            >>> ExcerptURIs.is_excerpt_uri("https://w3id.org/linkml/excerpt")
+            True
+            >>> ExcerptURIs.is_excerpt_uri("dcterms:title")
+            False
+        """
+        uri_lower = uri.lower()
+        return any(pattern in uri_lower for pattern in cls.MATCH_PATTERNS)
+
+
+@dataclass(frozen=True)
+class ReferenceURIs:
+    """URIs that identify a slot as an authoritative reference field.
+
+    Canonical URI is from Dublin Core.
+    Legacy URIs are supported for backwards compatibility.
+
+    Examples:
+        >>> ReferenceURIs.CANONICAL
+        'http://purl.org/dc/terms/references'
+        >>> ReferenceURIs.is_reference_uri("dcterms:references")
+        True
+        >>> ReferenceURIs.is_reference_uri("linkml:authoritative_reference")
+        True
+    """
+
+    # Canonical: Dublin Core - "related resource that is referenced, cited"
+    CANONICAL: str = "http://purl.org/dc/terms/references"
+    CANONICAL_PREFIXED: str = "dcterms:references"
+
+    # Alternative canonical: Dublin Core source
+    CANONICAL_ALT: str = "http://purl.org/dc/terms/source"
+    CANONICAL_ALT_PREFIXED: str = "dcterms:source"
+
+    # Legacy: LinkML authoritative_reference
+    LEGACY_LINKML: str = "https://w3id.org/linkml/authoritative_reference"
+    LEGACY_LINKML_PREFIXED: str = "linkml:authoritative_reference"
+
+    # Additional patterns to match (substrings)
+    MATCH_PATTERNS: tuple[str, ...] = (
+        "dcterms:references",
+        "dc/terms/references",
+        "dcterms:source",
+        "dc/terms/source",
+        "authoritative_reference",
+        "reference",
+    )
+
+    @classmethod
+    def is_reference_uri(cls, uri: str) -> bool:
+        """Check if a URI identifies a reference field.
+
+        Args:
+            uri: URI string to check (can be full or prefixed)
+
+        Returns:
+            True if the URI matches any known reference pattern
+
+        Examples:
+            >>> ReferenceURIs.is_reference_uri("http://purl.org/dc/terms/references")
+            True
+            >>> ReferenceURIs.is_reference_uri("dcterms:references")
+            True
+            >>> ReferenceURIs.is_reference_uri("linkml:authoritative_reference")
+            True
+            >>> ReferenceURIs.is_reference_uri("https://w3id.org/linkml/authoritative_reference")
+            True
+            >>> ReferenceURIs.is_reference_uri("oa:exact")
+            False
+        """
+        uri_lower = uri.lower()
+        return any(pattern in uri_lower for pattern in cls.MATCH_PATTERNS)
+
+
+@dataclass(frozen=True)
+class TitleURIs:
+    """URIs that identify a slot as a title field.
+
+    Canonical URI is from Dublin Core.
+
+    Examples:
+        >>> TitleURIs.CANONICAL
+        'http://purl.org/dc/terms/title'
+        >>> TitleURIs.is_title_uri("dcterms:title")
+        True
+    """
+
+    # Canonical: Dublin Core title
+    CANONICAL: str = "http://purl.org/dc/terms/title"
+    CANONICAL_PREFIXED: str = "dcterms:title"
+
+    # Additional patterns to match (substrings)
+    MATCH_PATTERNS: tuple[str, ...] = (
+        "dcterms:title",
+        "dc/terms/title",
+    )
+
+    @classmethod
+    def is_title_uri(cls, uri: str) -> bool:
+        """Check if a URI identifies a title field.
+
+        Args:
+            uri: URI string to check (can be full or prefixed)
+
+        Returns:
+            True if the URI matches any known title pattern
+
+        Examples:
+            >>> TitleURIs.is_title_uri("http://purl.org/dc/terms/title")
+            True
+            >>> TitleURIs.is_title_uri("dcterms:title")
+            True
+            >>> TitleURIs.is_title_uri("oa:exact")
+            False
+        """
+        uri_lower = uri.lower()
+        # Also match exact "title" for implements
+        if uri_lower == "title":
+            return True
+        return any(pattern in uri_lower for pattern in cls.MATCH_PATTERNS)
+
+
+# =============================================================================
+# Slot Protocol (for type hints without requiring linkml dependency)
+# =============================================================================
+
+class SlotLike(Protocol):
+    """Protocol for slot-like objects from LinkML SchemaView."""
+
+    @property
+    def implements(self) -> Optional[list[str]]:
+        """List of interface URIs this slot implements."""
+        ...
+
+    @property
+    def slot_uri(self) -> Optional[str]:
+        """The URI for this slot."""
+        ...
+
+
+# =============================================================================
+# CURIE Expansion
+# =============================================================================
+
+def expand_curie(
+    curie: str,
+    converter: Optional["Converter"] = None,
+) -> str:
+    """Expand a CURIE to a full URI using a curies Converter.
+
+    If the CURIE cannot be expanded (no matching prefix), returns the original.
+
+    Args:
+        curie: A CURIE like "dc:references" or a full URI
+        converter: A curies.Converter instance for prefix expansion
+
+    Returns:
+        Expanded URI or original string if no expansion possible
+
+    Examples:
+        >>> from curies import Converter
+        >>> conv = Converter.from_prefix_map({"dc": "http://purl.org/dc/terms/"})
+        >>> expand_curie("dc:references", conv)
+        'http://purl.org/dc/terms/references'
+        >>> expand_curie("http://example.org/foo", conv)
+        'http://example.org/foo'
+        >>> expand_curie("unknown:foo", conv)
+        'unknown:foo'
+        >>> expand_curie("dc:title", None)
+        'dc:title'
+    """
+    if converter is None:
+        return curie
+
+    # Already a full URI
+    if curie.startswith("http://") or curie.startswith("https://"):
+        return curie
+
+    # Try to expand using converter
+    expanded = converter.expand(curie)
+    return expanded if expanded is not None else curie
+
+
+def _check_uri_match(
+    uri: str,
+    check_fn: Callable[[str], bool],
+    converter: Optional["Converter"] = None,
+) -> bool:
+    """Check if a URI matches using the given check function, with optional CURIE expansion.
+
+    Args:
+        uri: URI or CURIE to check
+        check_fn: Function like ExcerptURIs.is_excerpt_uri
+        converter: Optional curies.Converter for CURIE expansion
+
+    Returns:
+        True if the URI matches (either as-is or after expansion)
+    """
+    # Check original form first
+    if check_fn(uri):
+        return True
+
+    # Try expanded form if we have a converter
+    if converter:
+        expanded = expand_curie(uri, converter)
+        if expanded != uri and check_fn(expanded):
+            return True
+
+    return False
+
+
+# =============================================================================
+# Field Detection Functions
+# =============================================================================
+
+def is_excerpt_slot(
+    slot: SlotLike,
+    converter: Optional["Converter"] = None,
+) -> bool:
+    """Check if a slot represents an excerpt/supporting text field.
+
+    Checks both `implements` list and `slot_uri`. Supports custom prefixes
+    via a curies.Converter.
+
+    Args:
+        slot: A slot object with implements and slot_uri attributes
+        converter: Optional curies.Converter for CURIE expansion
+
+    Returns:
+        True if the slot represents an excerpt field
+
+    Examples:
+        >>> from unittest.mock import Mock
+        >>> slot = Mock(implements=["oa:exact"], slot_uri=None)
+        >>> is_excerpt_slot(slot)
+        True
+        >>> slot = Mock(implements=["linkml:excerpt"], slot_uri=None)
+        >>> is_excerpt_slot(slot)
+        True
+        >>> slot = Mock(implements=None, slot_uri="http://www.w3.org/ns/oa#exact")
+        >>> is_excerpt_slot(slot)
+        True
+        >>> slot = Mock(implements=["dcterms:title"], slot_uri=None)
+        >>> is_excerpt_slot(slot)
+        False
+        >>> from curies import Converter
+        >>> conv = Converter.from_prefix_map({"ann": "http://www.w3.org/ns/oa#"})
+        >>> slot = Mock(implements=["ann:exact"], slot_uri=None)
+        >>> is_excerpt_slot(slot, conv)
+        True
+    """
+    if slot.implements:
+        for uri in slot.implements:
+            if _check_uri_match(uri, ExcerptURIs.is_excerpt_uri, converter):
+                return True
+
+    if slot.slot_uri:
+        if _check_uri_match(slot.slot_uri, ExcerptURIs.is_excerpt_uri, converter):
+            return True
+
+    return False
+
+
+def is_reference_slot(
+    slot: SlotLike,
+    converter: Optional["Converter"] = None,
+) -> bool:
+    """Check if a slot represents an authoritative reference field.
+
+    Checks both `implements` list and `slot_uri`. Supports custom prefixes
+    via a curies.Converter.
+
+    Args:
+        slot: A slot object with implements and slot_uri attributes
+        converter: Optional curies.Converter for CURIE expansion
+
+    Returns:
+        True if the slot represents a reference field
+
+    Examples:
+        >>> from unittest.mock import Mock
+        >>> slot = Mock(implements=["dcterms:references"], slot_uri=None)
+        >>> is_reference_slot(slot)
+        True
+        >>> slot = Mock(implements=["linkml:authoritative_reference"], slot_uri=None)
+        >>> is_reference_slot(slot)
+        True
+        >>> slot = Mock(implements=None, slot_uri="http://purl.org/dc/terms/references")
+        >>> is_reference_slot(slot)
+        True
+        >>> slot = Mock(implements=["oa:exact"], slot_uri=None)
+        >>> is_reference_slot(slot)
+        False
+        >>> from curies import Converter
+        >>> conv = Converter.from_prefix_map({"dc": "http://purl.org/dc/terms/"})
+        >>> slot = Mock(implements=["dc:references"], slot_uri=None)
+        >>> is_reference_slot(slot, conv)
+        True
+    """
+    if slot.implements:
+        for uri in slot.implements:
+            if _check_uri_match(uri, ReferenceURIs.is_reference_uri, converter):
+                return True
+
+    if slot.slot_uri:
+        if _check_uri_match(slot.slot_uri, ReferenceURIs.is_reference_uri, converter):
+            return True
+
+    return False
+
+
+def is_title_slot(
+    slot: SlotLike,
+    converter: Optional["Converter"] = None,
+) -> bool:
+    """Check if a slot represents a title field.
+
+    Checks both `implements` list and `slot_uri`. Supports custom prefixes
+    via a curies.Converter.
+
+    Args:
+        slot: A slot object with implements and slot_uri attributes
+        converter: Optional curies.Converter for CURIE expansion
+
+    Returns:
+        True if the slot represents a title field
+
+    Examples:
+        >>> from unittest.mock import Mock
+        >>> slot = Mock(implements=["dcterms:title"], slot_uri=None)
+        >>> is_title_slot(slot)
+        True
+        >>> slot = Mock(implements=None, slot_uri="http://purl.org/dc/terms/title")
+        >>> is_title_slot(slot)
+        True
+        >>> slot = Mock(implements=["oa:exact"], slot_uri=None)
+        >>> is_title_slot(slot)
+        False
+        >>> from curies import Converter
+        >>> conv = Converter.from_prefix_map({"dc": "http://purl.org/dc/terms/"})
+        >>> slot = Mock(implements=["dc:title"], slot_uri=None)
+        >>> is_title_slot(slot, conv)
+        True
+    """
+    if slot.implements:
+        for uri in slot.implements:
+            if _check_uri_match(uri, TitleURIs.is_title_uri, converter):
+                return True
+
+    if slot.slot_uri:
+        if _check_uri_match(slot.slot_uri, TitleURIs.is_title_uri, converter):
+            return True
+
+    return False
+
+
+# =============================================================================
+# Fallback Slot Names
+# =============================================================================
+
+@dataclass(frozen=True)
+class FallbackSlotNames:
+    """Fallback slot names when no URI-based detection matches.
+
+    These are used as a last resort when slots don't have explicit
+    `implements` or `slot_uri` annotations.
+
+    Examples:
+        >>> "reference" in FallbackSlotNames.REFERENCE
+        True
+        >>> "supporting_text" in FallbackSlotNames.EXCERPT
+        True
+    """
+
+    EXCERPT: tuple[str, ...] = ("supporting_text",)
+    REFERENCE: tuple[str, ...] = ("reference", "reference_id")
+    TITLE: tuple[str, ...] = ("title",)

--- a/tests/data/test_schema.yaml
+++ b/tests/data/test_schema.yaml
@@ -4,6 +4,8 @@ description: Test schema for reference validation
 
 prefixes:
   linkml: https://w3id.org/linkml/
+  oa: http://www.w3.org/ns/oa#
+  dcterms: http://purl.org/dc/terms/
   test: https://example.org/test/
 
 default_prefix: test
@@ -15,11 +17,11 @@ classes:
       reference:
         range: Reference
         implements:
-          - linkml:authoritative_reference
+          - dcterms:references
       supporting_text:
         range: string
         implements:
-          - linkml:excerpt
+          - oa:exact
 
   Reference:
     description: A reference to a publication

--- a/tests/test_field_detection.py
+++ b/tests/test_field_detection.py
@@ -1,0 +1,425 @@
+"""Tests for field detection module.
+
+Tests that both canonical and legacy URIs are correctly identified.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from curies import Converter
+
+from linkml_reference_validator.field_detection import (
+    ExcerptURIs,
+    FallbackSlotNames,
+    ReferenceURIs,
+    TitleURIs,
+    expand_curie,
+    is_excerpt_slot,
+    is_reference_slot,
+    is_title_slot,
+)
+
+
+class TestExcerptURIs:
+    """Tests for ExcerptURIs detection."""
+
+    @pytest.mark.parametrize(
+        "uri,expected",
+        [
+            # Canonical URIs
+            ("http://www.w3.org/ns/oa#exact", True),
+            ("oa:exact", True),
+            # Legacy URIs
+            ("https://w3id.org/linkml/excerpt", True),
+            ("linkml:excerpt", True),
+            # Substring matches
+            ("http://example.org/myExcerptField", True),
+            ("supporting_text", True),
+            # Non-matching URIs
+            ("dcterms:title", False),
+            ("dcterms:references", False),
+            ("http://example.org/something", False),
+            ("linkml:authoritative_reference", False),
+        ],
+    )
+    def test_is_excerpt_uri(self, uri: str, expected: bool):
+        """Test that excerpt URIs are correctly identified."""
+        assert ExcerptURIs.is_excerpt_uri(uri) == expected
+
+    def test_canonical_constant(self):
+        """Test canonical URI constant."""
+        assert ExcerptURIs.CANONICAL == "http://www.w3.org/ns/oa#exact"
+        assert ExcerptURIs.CANONICAL_PREFIXED == "oa:exact"
+
+    def test_legacy_constant(self):
+        """Test legacy URI constant."""
+        assert ExcerptURIs.LEGACY_LINKML == "https://w3id.org/linkml/excerpt"
+        assert ExcerptURIs.LEGACY_LINKML_PREFIXED == "linkml:excerpt"
+
+
+class TestReferenceURIs:
+    """Tests for ReferenceURIs detection."""
+
+    @pytest.mark.parametrize(
+        "uri,expected",
+        [
+            # Canonical URIs
+            ("http://purl.org/dc/terms/references", True),
+            ("dcterms:references", True),
+            ("http://purl.org/dc/terms/source", True),
+            ("dcterms:source", True),
+            # Legacy URIs
+            ("https://w3id.org/linkml/authoritative_reference", True),
+            ("linkml:authoritative_reference", True),
+            # Substring matches
+            ("http://example.org/myReferenceField", True),
+            # Non-matching URIs
+            ("dcterms:title", False),
+            ("oa:exact", False),
+            ("linkml:excerpt", False),
+            ("http://example.org/something", False),
+        ],
+    )
+    def test_is_reference_uri(self, uri: str, expected: bool):
+        """Test that reference URIs are correctly identified."""
+        assert ReferenceURIs.is_reference_uri(uri) == expected
+
+    def test_canonical_constant(self):
+        """Test canonical URI constant."""
+        assert ReferenceURIs.CANONICAL == "http://purl.org/dc/terms/references"
+        assert ReferenceURIs.CANONICAL_PREFIXED == "dcterms:references"
+
+    def test_legacy_constant(self):
+        """Test legacy URI constant."""
+        assert (
+            ReferenceURIs.LEGACY_LINKML
+            == "https://w3id.org/linkml/authoritative_reference"
+        )
+        assert ReferenceURIs.LEGACY_LINKML_PREFIXED == "linkml:authoritative_reference"
+
+
+class TestTitleURIs:
+    """Tests for TitleURIs detection."""
+
+    @pytest.mark.parametrize(
+        "uri,expected",
+        [
+            # Canonical URIs
+            ("http://purl.org/dc/terms/title", True),
+            ("dcterms:title", True),
+            # Exact match on "title" (for implements)
+            ("title", True),
+            # Non-matching URIs
+            ("oa:exact", False),
+            ("dcterms:references", False),
+            ("http://example.org/something", False),
+            ("linkml:excerpt", False),
+        ],
+    )
+    def test_is_title_uri(self, uri: str, expected: bool):
+        """Test that title URIs are correctly identified."""
+        assert TitleURIs.is_title_uri(uri) == expected
+
+    def test_canonical_constant(self):
+        """Test canonical URI constant."""
+        assert TitleURIs.CANONICAL == "http://purl.org/dc/terms/title"
+        assert TitleURIs.CANONICAL_PREFIXED == "dcterms:title"
+
+
+class TestIsExcerptSlot:
+    """Tests for is_excerpt_slot function."""
+
+    def test_canonical_implements(self):
+        """Test slot with canonical URI in implements."""
+        slot = Mock(implements=["oa:exact"], slot_uri=None)
+        assert is_excerpt_slot(slot) is True
+
+    def test_canonical_full_implements(self):
+        """Test slot with canonical full URI in implements."""
+        slot = Mock(implements=["http://www.w3.org/ns/oa#exact"], slot_uri=None)
+        assert is_excerpt_slot(slot) is True
+
+    def test_legacy_implements(self):
+        """Test slot with legacy URI in implements."""
+        slot = Mock(implements=["linkml:excerpt"], slot_uri=None)
+        assert is_excerpt_slot(slot) is True
+
+    def test_canonical_slot_uri(self):
+        """Test slot with canonical URI as slot_uri."""
+        slot = Mock(implements=None, slot_uri="http://www.w3.org/ns/oa#exact")
+        assert is_excerpt_slot(slot) is True
+
+    def test_non_excerpt_slot(self):
+        """Test slot that is not an excerpt field."""
+        slot = Mock(implements=["dcterms:title"], slot_uri=None)
+        assert is_excerpt_slot(slot) is False
+
+    def test_empty_slot(self):
+        """Test slot with no implements or slot_uri."""
+        slot = Mock(implements=None, slot_uri=None)
+        assert is_excerpt_slot(slot) is False
+
+    def test_multiple_implements(self):
+        """Test slot with multiple implements including excerpt."""
+        slot = Mock(implements=["dcterms:description", "oa:exact"], slot_uri=None)
+        assert is_excerpt_slot(slot) is True
+
+
+class TestIsReferenceSlot:
+    """Tests for is_reference_slot function."""
+
+    def test_canonical_implements(self):
+        """Test slot with canonical URI in implements."""
+        slot = Mock(implements=["dcterms:references"], slot_uri=None)
+        assert is_reference_slot(slot) is True
+
+    def test_canonical_source_implements(self):
+        """Test slot with canonical source URI in implements."""
+        slot = Mock(implements=["dcterms:source"], slot_uri=None)
+        assert is_reference_slot(slot) is True
+
+    def test_legacy_implements(self):
+        """Test slot with legacy URI in implements."""
+        slot = Mock(implements=["linkml:authoritative_reference"], slot_uri=None)
+        assert is_reference_slot(slot) is True
+
+    def test_canonical_slot_uri(self):
+        """Test slot with canonical URI as slot_uri."""
+        slot = Mock(implements=None, slot_uri="http://purl.org/dc/terms/references")
+        assert is_reference_slot(slot) is True
+
+    def test_non_reference_slot(self):
+        """Test slot that is not a reference field."""
+        slot = Mock(implements=["dcterms:title"], slot_uri=None)
+        assert is_reference_slot(slot) is False
+
+
+class TestIsTitleSlot:
+    """Tests for is_title_slot function."""
+
+    def test_canonical_implements(self):
+        """Test slot with canonical URI in implements."""
+        slot = Mock(implements=["dcterms:title"], slot_uri=None)
+        assert is_title_slot(slot) is True
+
+    def test_canonical_slot_uri(self):
+        """Test slot with canonical URI as slot_uri."""
+        slot = Mock(implements=None, slot_uri="http://purl.org/dc/terms/title")
+        assert is_title_slot(slot) is True
+
+    def test_title_exact_implements(self):
+        """Test slot with 'title' exactly in implements."""
+        slot = Mock(implements=["title"], slot_uri=None)
+        assert is_title_slot(slot) is True
+
+    def test_non_title_slot(self):
+        """Test slot that is not a title field."""
+        slot = Mock(implements=["oa:exact"], slot_uri=None)
+        assert is_title_slot(slot) is False
+
+
+class TestFallbackSlotNames:
+    """Tests for fallback slot names."""
+
+    def test_excerpt_fallbacks(self):
+        """Test excerpt fallback names."""
+        assert "supporting_text" in FallbackSlotNames.EXCERPT
+
+    def test_reference_fallbacks(self):
+        """Test reference fallback names."""
+        assert "reference" in FallbackSlotNames.REFERENCE
+        assert "reference_id" in FallbackSlotNames.REFERENCE
+
+    def test_title_fallbacks(self):
+        """Test title fallback names."""
+        assert "title" in FallbackSlotNames.TITLE
+
+
+class TestAllCombinations:
+    """Test that all valid URI/mechanism combinations work.
+
+    Schema authors can use ANY of the supported URIs in EITHER
+    slot_uri OR implements. All combinations should work.
+    """
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            # Canonical
+            "oa:exact",
+            "http://www.w3.org/ns/oa#exact",
+            # Legacy
+            "linkml:excerpt",
+            "https://w3id.org/linkml/excerpt",
+        ],
+    )
+    def test_excerpt_via_implements(self, uri: str):
+        """Any excerpt URI in implements should be detected."""
+        slot = Mock(implements=[uri], slot_uri=None)
+        assert is_excerpt_slot(slot) is True
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            # Canonical
+            "oa:exact",
+            "http://www.w3.org/ns/oa#exact",
+            # Legacy
+            "linkml:excerpt",
+            "https://w3id.org/linkml/excerpt",
+        ],
+    )
+    def test_excerpt_via_slot_uri(self, uri: str):
+        """Any excerpt URI in slot_uri should be detected."""
+        slot = Mock(implements=None, slot_uri=uri)
+        assert is_excerpt_slot(slot) is True
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            # Canonical
+            "dcterms:references",
+            "http://purl.org/dc/terms/references",
+            # Legacy
+            "linkml:authoritative_reference",
+            "https://w3id.org/linkml/authoritative_reference",
+        ],
+    )
+    def test_reference_via_implements(self, uri: str):
+        """Any reference URI in implements should be detected."""
+        slot = Mock(implements=[uri], slot_uri=None)
+        assert is_reference_slot(slot) is True
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            # Canonical
+            "dcterms:references",
+            "http://purl.org/dc/terms/references",
+            # Legacy
+            "linkml:authoritative_reference",
+            "https://w3id.org/linkml/authoritative_reference",
+        ],
+    )
+    def test_reference_via_slot_uri(self, uri: str):
+        """Any reference URI in slot_uri should be detected."""
+        slot = Mock(implements=None, slot_uri=uri)
+        assert is_reference_slot(slot) is True
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "dcterms:title",
+            "http://purl.org/dc/terms/title",
+        ],
+    )
+    def test_title_via_implements(self, uri: str):
+        """Any title URI in implements should be detected."""
+        slot = Mock(implements=[uri], slot_uri=None)
+        assert is_title_slot(slot) is True
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "dcterms:title",
+            "http://purl.org/dc/terms/title",
+        ],
+    )
+    def test_title_via_slot_uri(self, uri: str):
+        """Any title URI in slot_uri should be detected."""
+        slot = Mock(implements=None, slot_uri=uri)
+        assert is_title_slot(slot) is True
+
+
+class TestExpandCurie:
+    """Tests for CURIE expansion."""
+
+    def test_expand_with_matching_prefix(self):
+        """CURIE is expanded when prefix matches."""
+        conv = Converter.from_prefix_map({"dc": "http://purl.org/dc/terms/"})
+        result = expand_curie("dc:references", conv)
+        assert result == "http://purl.org/dc/terms/references"
+
+    def test_expand_preserves_full_uri(self):
+        """Full URIs are returned unchanged."""
+        conv = Converter.from_prefix_map({"dc": "http://purl.org/dc/terms/"})
+        uri = "http://purl.org/dc/terms/title"
+        result = expand_curie(uri, conv)
+        assert result == uri
+
+    def test_expand_unknown_prefix(self):
+        """CURIEs with unknown prefixes are returned unchanged."""
+        conv = Converter.from_prefix_map({"dc": "http://purl.org/dc/terms/"})
+        result = expand_curie("unknown:foo", conv)
+        assert result == "unknown:foo"
+
+    def test_expand_no_converter(self):
+        """CURIEs are returned unchanged when no converter provided."""
+        result = expand_curie("dc:title", None)
+        assert result == "dc:title"
+
+    def test_expand_https_uri(self):
+        """HTTPS URIs are preserved."""
+        conv = Converter.from_prefix_map({"linkml": "https://w3id.org/linkml/"})
+        uri = "https://w3id.org/linkml/excerpt"
+        result = expand_curie(uri, conv)
+        assert result == uri
+
+
+class TestCustomPrefixes:
+    """Tests for custom prefix support in field detection.
+
+    Users may declare custom prefixes like 'dc' instead of 'dcterms'.
+    The detection functions should handle these via CURIE expansion.
+    """
+
+    def test_excerpt_with_custom_prefix(self):
+        """Excerpt field detected with custom prefix for oa namespace."""
+        slot = Mock(implements=["ann:exact"], slot_uri=None)
+        conv = Converter.from_prefix_map({"ann": "http://www.w3.org/ns/oa#"})
+        assert is_excerpt_slot(slot, conv) is True
+
+    def test_excerpt_with_custom_prefix_slot_uri(self):
+        """Excerpt field detected via slot_uri with custom prefix."""
+        slot = Mock(implements=None, slot_uri="annotation:exact")
+        conv = Converter.from_prefix_map({"annotation": "http://www.w3.org/ns/oa#"})
+        assert is_excerpt_slot(slot, conv) is True
+
+    def test_reference_with_dc_prefix(self):
+        """Reference field detected with 'dc' prefix instead of 'dcterms'."""
+        slot = Mock(implements=["dc:references"], slot_uri=None)
+        conv = Converter.from_prefix_map({"dc": "http://purl.org/dc/terms/"})
+        assert is_reference_slot(slot, conv) is True
+
+    def test_reference_with_dct_prefix(self):
+        """Reference field detected with 'dct' prefix."""
+        slot = Mock(implements=["dct:source"], slot_uri=None)
+        conv = Converter.from_prefix_map({"dct": "http://purl.org/dc/terms/"})
+        assert is_reference_slot(slot, conv) is True
+
+    def test_title_with_dc_prefix(self):
+        """Title field detected with 'dc' prefix instead of 'dcterms'."""
+        slot = Mock(implements=["dc:title"], slot_uri=None)
+        conv = Converter.from_prefix_map({"dc": "http://purl.org/dc/terms/"})
+        assert is_title_slot(slot, conv) is True
+
+    def test_title_with_custom_slot_uri(self):
+        """Title field detected via slot_uri with custom prefix."""
+        slot = Mock(implements=None, slot_uri="mydcterms:title")
+        conv = Converter.from_prefix_map({"mydcterms": "http://purl.org/dc/terms/"})
+        assert is_title_slot(slot, conv) is True
+
+    def test_unknown_prefix_not_matched(self):
+        """Unknown prefix without mapping is not matched."""
+        slot = Mock(implements=["unknown:exact"], slot_uri=None)
+        conv = Converter.from_prefix_map({"dc": "http://purl.org/dc/terms/"})
+        # Should not match because 'unknown' prefix is not in map
+        # and doesn't match any pattern directly
+        assert is_excerpt_slot(slot, conv) is False
+
+    def test_standard_prefix_works_without_converter(self):
+        """Standard prefixes like 'dcterms:' work even without converter."""
+        slot = Mock(implements=["dcterms:references"], slot_uri=None)
+        assert is_reference_slot(slot, None) is True
+        assert is_reference_slot(slot) is True


### PR DESCRIPTION
## Summary

- Add support for standard semantic web URIs as canonical identifiers for excerpt, reference, and title fields
- **Excerpt**: `oa:exact` (http://www.w3.org/ns/oa#exact) from W3C Web Annotation
- **Reference**: `dcterms:references` (http://purl.org/dc/terms/references) from Dublin Core  
- **Title**: `dcterms:title` (http://purl.org/dc/terms/title) from Dublin Core
- Legacy `linkml:excerpt` and `linkml:authoritative_reference` URIs remain supported for backwards compatibility
- New `field_detection.py` module with clean separation of concerns
- Detection logic supports both `slot_uri` and `implements`
- Custom prefix handling via `curies` library (schema prefix expansion)

## Schema Usage

All combinations work - any supported URI in either `slot_uri` or `implements`:

```yaml
prefixes:
  oa: http://www.w3.org/ns/oa#
  dcterms: http://purl.org/dc/terms/
  dc: http://purl.org/dc/terms/  # custom prefix also works

slots:
  supporting_text:
    implements:
      - oa:exact           # canonical
      # - linkml:excerpt   # legacy still works
  
  reference:
    implements:
      - dcterms:references  # canonical
      - dc:references       # custom prefix works too
      # - linkml:authoritative_reference  # legacy still works
```

## Test plan

- [x] 85 new tests for field detection covering all URI/mechanism combinations
- [x] All 396 existing tests pass
- [x] 66 doctests pass
- [x] mypy type checking passes

🤖 Generated with [Claude Code](https://claude.ai/code)