### PR TITLE
feat: Add GEO accession-to-UID conversion and CLI title validation

### DIFF
--- a/docs/how-to/validate-entrez.md
+++ b/docs/how-to/validate-entrez.md
@@ -4,11 +4,11 @@ This guide shows how to validate supporting text against NCBI Entrez records for
 
 ## Overview
 
-These sources use the NCBI Entrez E-utilities `esummary` endpoint:
+These sources use the NCBI Entrez E-utilities:
 
-- **GEO** (GSE/GDS): summaries from the `gds` database
-- **BioProject** (PRJNA/PRJEB/PRJDB): summaries from the `bioproject` database
-- **BioSample** (SAMN/SAME/SAMD): summaries from the `biosample` database
+- **GEO** (GSE/GDS): Uses `esearch` to convert accessions to UIDs, then `esummary` from the `gds` database
+- **BioProject** (PRJNA/PRJEB/PRJDB): Uses `esummary` from the `bioproject` database
+- **BioSample** (SAMN/SAME/SAMD): Uses `esummary` from the `biosample` database
 
 The validator uses the returned summary/description fields as the content for matching.
 
@@ -21,6 +21,20 @@ linkml-reference-validator validate text \
   "RNA-seq analysis of cardiac tissue" \
   GEO:GSE12345
 ```
+
+### Validating with Title Check
+
+You can also validate that the reference title matches your expected title:
+
+```bash
+# This will validate both the excerpt AND the title
+linkml-reference-validator validate text \
+  "Airway epithelial brushings" \
+  GEO:GSE67472 \
+  --title "Airway epithelial gene expression in asthma versus healthy controls"
+```
+
+If the title doesn't match, validation will fail with a "title mismatch" error.
 
 ### BioProject
 
@@ -109,8 +123,107 @@ config = ReferenceValidationConfig(
 Entrez summaries vary by record. If a summary field is missing, the validator will return
 `content_type: unavailable` and matching may fail.
 
+## Validation Failure Scenarios
+
+The validator catches several types of errors:
+
+### Excerpt Not Found
+
+When the quoted text is not in the reference content:
+
+```bash
+$ linkml-reference-validator validate text \
+    "text that is not in the dataset" \
+    GEO:GSE67472
+
+Result:
+  Valid: False
+  Message: Text part not found as substring: 'text that is not in the dataset'
+```
+
+### Title Mismatch
+
+When the expected title doesn't match the actual reference title:
+
+```bash
+$ linkml-reference-validator validate text \
+    "Airway epithelial brushings" \
+    GEO:GSE67472 \
+    --title "Wrong Title Here"
+
+Result:
+  Valid: False
+  Message: Title mismatch for GEO:GSE67472
+    Expected: "Wrong Title Here"
+    Actual: "Airway epithelial gene expression in asthma versus healthy controls"
+```
+
+### Reference Not Found
+
+When the accession doesn't exist:
+
+```bash
+$ linkml-reference-validator validate text \
+    "Some text" \
+    GEO:GSE99999999999
+
+Result:
+  Valid: False
+  Message: Could not fetch reference GEO:GSE99999999999
+```
+
+## Configuration File
+
+Create `.linkml-reference-validator.yaml` in your project root for persistent configuration:
+
+```yaml
+validation:
+  # NCBI requires a valid email for Entrez API usage
+  email: you@example.org
+
+  # Rate limiting (seconds between API calls)
+  rate_limit_delay: 0.5
+
+  # Cache directory for offline use
+  cache_dir: references_cache
+
+  # Map alternate prefixes to canonical forms
+  reference_prefix_map:
+    geo: GEO
+    NCBIGeo: GEO
+    NCBIBioProject: BIOPROJECT
+    NCBIBioSample: BIOSAMPLE
+```
+
+Pass the config to CLI commands:
+
+```bash
+linkml-reference-validator validate text \
+  "Some text" \
+  GEO:GSE67472 \
+  --config .linkml-reference-validator.yaml
+```
+
+## How GEO Accession-to-UID Conversion Works
+
+The GDS Entrez database requires numeric UIDs, not accession numbers like GSE67472.
+The GEOSource automatically handles this conversion:
+
+1. **esearch**: Searches for the accession and returns the numeric UID
+   ```
+   esearch(db="gds", term="GSE67472[Accession]") → "200067472"
+   ```
+
+2. **esummary**: Uses the UID to fetch the dataset metadata
+   ```
+   esummary(db="gds", id="200067472") → {title, summary, ...}
+   ```
+
+This conversion happens transparently - you just use the GSE/GDS accession.
+
 ## See Also
 
 - [Adding a New Reference Source](add-reference-source.md)
+- [Validating Titles](validate-titles.md)
 - [Quickstart](../quickstart.md)
 - [CLI Reference](../reference/cli.md)

--- a/src/linkml_reference_validator/etl/sources/entrez.py
+++ b/src/linkml_reference_validator/etl/sources/entrez.py
@@ -185,6 +185,9 @@ class EntrezSummarySource(ReferenceSource):
 class GEOSource(EntrezSummarySource):
     """Fetch GEO series and dataset summaries from Entrez.
 
+    The GDS Entrez database requires numeric UIDs, not accession numbers.
+    This source converts GSE/GDS accessions to UIDs via esearch before fetching.
+
     Examples:
         >>> GEOSource.prefix()
         'GEO'
@@ -196,7 +199,94 @@ class GEOSource(EntrezSummarySource):
     ENTREZ_DB = "gds"
     TITLE_FIELDS = ("title", "description", "summary")
     CONTENT_FIELDS = ("summary", "description", "title")
-    ID_PATTERNS = (r"^GSE\\d+$", r"^GDS\\d+$")
+    ID_PATTERNS = (r"^GSE\d+$", r"^GDS\d+$")
+
+    def fetch(
+        self, identifier: str, config: ReferenceValidationConfig
+    ) -> Optional[ReferenceContent]:
+        """Fetch GEO dataset metadata, converting accession to UID first.
+
+        The GDS Entrez database does not accept accession numbers (e.g. GSE67472)
+        directly in esummary - it requires numeric UIDs (e.g. 200067472).
+        This method uses esearch to convert accessions to UIDs first.
+
+        Args:
+            identifier: GEO accession (GSE or GDS number)
+            config: Configuration including rate limiting and email
+
+        Returns:
+            ReferenceContent if successful, None otherwise
+        """
+        Entrez.email = config.email  # type: ignore
+        time.sleep(config.rate_limit_delay)
+
+        # Convert accession to UID via esearch
+        uid = self._accession_to_uid(identifier, config)
+        if not uid:
+            logger.warning(f"Could not find GDS UID for {identifier}")
+            return None
+
+        # Now fetch summary with numeric UID
+        handle = None
+        try:
+            handle = Entrez.esummary(db=self.ENTREZ_DB, id=uid)
+            records = Entrez.read(handle)
+        except Exception as exc:
+            logger.warning(
+                f"Failed to fetch Entrez summary for {self.prefix()}:{identifier}: {exc}"
+            )
+            return None
+        finally:
+            if handle is not None:
+                handle.close()
+
+        record = self._extract_record(records)
+        if not record:
+            logger.warning(f"No Entrez summary found for {self.prefix()}:{identifier}")
+            return None
+
+        title = self._get_first_field_value(record, self.TITLE_FIELDS)
+        content = self._get_first_field_value(record, self.CONTENT_FIELDS)
+        content_type = "summary" if content else "unavailable"
+
+        return ReferenceContent(
+            reference_id=f"{self.prefix()}:{identifier}",
+            title=title,
+            content=content,
+            content_type=content_type,
+            metadata={"entrez_db": self.ENTREZ_DB, "entrez_uid": uid},
+        )
+
+    def _accession_to_uid(
+        self, accession: str, config: ReferenceValidationConfig
+    ) -> Optional[str]:
+        """Convert a GEO accession (GSE/GDS) to its Entrez UID.
+
+        Examples:
+            >>> source = GEOSource()
+            >>> # This would require network access to actually run:
+            >>> # source._accession_to_uid("GSE67472", config)  # Returns "200067472"
+
+        Args:
+            accession: GEO accession like GSE67472 or GDS1234
+            config: Configuration for rate limiting
+
+        Returns:
+            Numeric UID string if found, None otherwise
+        """
+        time.sleep(config.rate_limit_delay)
+        handle = None
+        try:
+            handle = Entrez.esearch(db=self.ENTREZ_DB, term=f"{accession}[Accession]")
+            result = Entrez.read(handle)
+            if result.get("IdList"):
+                return result["IdList"][0]
+        except Exception as exc:
+            logger.warning(f"esearch failed for {accession}: {exc}")
+        finally:
+            if handle is not None:
+                handle.close()
+        return None
 
 
 @ReferenceSourceRegistry.register

--- a/tests/fixtures/GEO_GSE12345.md
+++ b/tests/fixtures/GEO_GSE12345.md
@@ -1,0 +1,11 @@
+---
+reference_id: GEO:GSE12345
+title: Test GEO Dataset for Validation
+content_type: summary
+---
+
+# Test GEO Dataset for Validation
+
+## Content
+
+This is a test GEO dataset for validating the GEOSource implementation. The dataset contains gene expression profiles from human samples. Airway epithelial cells were collected from asthma patients and healthy controls. Differential expression analysis identified genes involved in inflammatory response pathways. The study provides insights into molecular mechanisms of airway inflammation in asthma.

--- a/tests/test_geo_integration.py
+++ b/tests/test_geo_integration.py
@@ -1,0 +1,333 @@
+"""Integration tests for GEO reference source.
+
+Tests using real cached fixtures and optional live API tests.
+"""
+
+import pytest
+from linkml_reference_validator.models import ReferenceValidationConfig, ValidationSeverity
+from linkml_reference_validator.etl.sources.entrez import GEOSource
+
+
+class TestGEOIntegration:
+    """Integration tests using cached GEO fixtures."""
+
+    def test_fetch_cached_geo_reference(self, fetcher_with_fixtures):
+        """Test fetching a cached GEO reference."""
+        ref = fetcher_with_fixtures.fetch("GEO:GSE12345")
+
+        assert ref is not None
+        assert ref.reference_id == "GEO:GSE12345"
+        assert ref.title == "Test GEO Dataset for Validation"
+        assert "gene expression profiles" in ref.content
+        assert ref.content_type == "summary"
+
+    def test_validate_geo_reference_success(self, validator_with_fixtures):
+        """Test validation with cached GEO reference - success case."""
+        result = validator_with_fixtures.validate(
+            "gene expression profiles from human samples",
+            "GEO:GSE12345",
+        )
+
+        assert result.is_valid is True
+        assert result.severity == ValidationSeverity.INFO
+        assert result.match_result is not None
+        assert result.match_result.found is True
+
+    def test_validate_geo_reference_substring(self, validator_with_fixtures):
+        """Test substring matching with GEO reference."""
+        result = validator_with_fixtures.validate(
+            "airway inflammation in asthma",
+            "GEO:GSE12345",
+        )
+
+        assert result.is_valid is True
+
+    def test_validate_geo_reference_not_found(self, validator_with_fixtures):
+        """Test validation when text is not in GEO reference."""
+        result = validator_with_fixtures.validate(
+            "this text is definitely not in any GEO dataset",
+            "GEO:GSE12345",
+        )
+
+        assert result.is_valid is False
+        assert result.severity == ValidationSeverity.ERROR
+        assert "not found" in result.message.lower()
+
+    def test_validate_geo_with_title_validation(self, validator_with_fixtures):
+        """Test validation with GEO title check."""
+        result = validator_with_fixtures.validate(
+            "gene expression profiles",
+            "GEO:GSE12345",
+            expected_title="Test GEO Dataset for Validation",
+        )
+
+        assert result.is_valid is True
+        assert "title validated" in result.message
+
+    def test_validate_geo_title_mismatch(self, validator_with_fixtures):
+        """Test validation with GEO title mismatch."""
+        result = validator_with_fixtures.validate(
+            "gene expression profiles",
+            "GEO:GSE12345",
+            expected_title="Wrong Dataset Title",
+        )
+
+        assert result.is_valid is False
+        assert result.severity == ValidationSeverity.ERROR
+        assert "title mismatch" in result.message.lower()
+
+    def test_validate_geo_multipart_quote(self, validator_with_fixtures):
+        """Test validation with multi-part quote using ellipsis."""
+        result = validator_with_fixtures.validate(
+            "gene expression profiles ... airway epithelial cells",
+            "GEO:GSE12345",
+        )
+
+        assert result.is_valid is True
+
+    def test_fetch_nonexistent_geo(self, fetcher_with_fixtures):
+        """Test fetcher returns None for nonexistent GEO dataset."""
+        ref = fetcher_with_fixtures.fetch("GEO:GSE99999999")
+
+        assert ref is None
+
+
+class TestGEOSourceDirect:
+    """Direct tests for GEOSource class."""
+
+    @pytest.fixture
+    def source(self):
+        """Create GEOSource instance."""
+        return GEOSource()
+
+    @pytest.fixture
+    def config(self, tmp_path):
+        """Create test config."""
+        return ReferenceValidationConfig(
+            cache_dir=tmp_path / "cache",
+            rate_limit_delay=0.0,
+        )
+
+    def test_source_prefix(self, source):
+        """Test source prefix is 'GEO'."""
+        assert source.prefix() == "GEO"
+
+    def test_can_handle_various_formats(self, source):
+        """Test can_handle accepts various GEO ID formats."""
+        # Prefixed formats
+        assert source.can_handle("GEO:GSE12345")
+        assert source.can_handle("geo:GSE12345")
+        assert source.can_handle("GEO:GDS1234")
+
+        # Bare accessions (GSE/GDS patterns)
+        assert source.can_handle("GSE12345")
+        assert source.can_handle("GDS1234")
+        assert source.can_handle("GSE67472")
+
+        # Other prefixes should not be handled
+        assert not source.can_handle("PMID:12345678")
+        assert not source.can_handle("DOI:10.1234/test")
+        assert not source.can_handle("NCT12345678")
+
+
+@pytest.mark.integration
+class TestGEOLiveAPI:
+    """Live API tests for GEO/Entrez.
+
+    These tests make real network requests and are marked with @pytest.mark.integration.
+    Run with: pytest -m integration
+    Skip with: pytest -m "not integration"
+    """
+
+    @pytest.fixture
+    def source(self):
+        """Create GEOSource instance."""
+        return GEOSource()
+
+    @pytest.fixture
+    def config(self, tmp_path):
+        """Create test config with reasonable rate limiting."""
+        return ReferenceValidationConfig(
+            cache_dir=tmp_path / "cache",
+            rate_limit_delay=0.5,  # Be respectful to the API
+            email="test@example.com",
+        )
+
+    def test_fetch_real_geo_dataset_gse67472(self, source, config):
+        """Test fetching a real GEO dataset (GSE67472).
+
+        GSE67472: Airway epithelial gene expression in asthma versus healthy controls
+        This is a real, published dataset that should be stable.
+        """
+        result = source.fetch("GSE67472", config)
+
+        assert result is not None
+        assert result.reference_id == "GEO:GSE67472"
+        assert result.title is not None
+        assert len(result.title) > 0
+        # The title should contain something about asthma or airways
+        assert "asthma" in result.title.lower() or "airway" in result.title.lower()
+        assert result.content is not None
+        assert len(result.content) > 0
+        assert result.content_type == "summary"
+        # Should have UID in metadata (the converted numeric ID)
+        assert "entrez_uid" in result.metadata
+        assert result.metadata["entrez_uid"].isdigit()
+
+    def test_fetch_real_geo_dataset_gds1234(self, source, config):
+        """Test fetching a real GDS dataset (GDS1234).
+
+        GDS1234 is a stable GEO dataset from earlier in GEO's history.
+        """
+        result = source.fetch("GDS1234", config)
+
+        assert result is not None
+        assert result.reference_id == "GEO:GDS1234"
+        assert result.title is not None
+        assert len(result.title) > 0
+        assert result.content is not None
+        assert result.content_type == "summary"
+        assert "entrez_uid" in result.metadata
+
+    def test_fetch_nonexistent_geo_dataset(self, source, config):
+        """Test fetching a nonexistent GEO accession returns None."""
+        result = source.fetch("GSE99999999999", config)
+
+        assert result is None
+
+    def test_accession_to_uid_conversion(self, source, config):
+        """Test that accession is properly converted to UID.
+
+        GSE67472 should convert to UID 200067472.
+        """
+        result = source.fetch("GSE67472", config)
+
+        assert result is not None
+        # The UID should be numeric and follow the pattern for GSE conversion
+        uid = result.metadata.get("entrez_uid")
+        assert uid is not None
+        assert uid.isdigit()
+        # GSE67472 should map to a UID around 200067472
+        assert int(uid) > 0
+
+
+@pytest.mark.integration
+class TestGEOLiveValidation:
+    """Live validation tests for GEO datasets.
+
+    These tests make real network requests to validate text and titles
+    against actual GEO datasets. Marked with @pytest.mark.integration.
+    """
+
+    @pytest.fixture
+    def config(self, tmp_path):
+        """Create test config with reasonable rate limiting."""
+        return ReferenceValidationConfig(
+            cache_dir=tmp_path / "cache",
+            rate_limit_delay=0.5,
+            email="test@example.com",
+        )
+
+    @pytest.fixture
+    def validator(self, config):
+        """Create a validator instance."""
+        from linkml_reference_validator.validation.supporting_text_validator import (
+            SupportingTextValidator,
+        )
+        return SupportingTextValidator(config)
+
+    def test_validate_excerpt_success_real_geo(self, validator):
+        """Test validating text that exists in a real GEO dataset.
+
+        GSE67472 contains text about "Airway epithelial brushings" and "asthma".
+        """
+        result = validator.validate(
+            "Airway epithelial brushings",
+            "GEO:GSE67472",
+        )
+
+        assert result.is_valid is True
+        assert result.severity == ValidationSeverity.INFO
+        assert result.match_result is not None
+        assert result.match_result.found is True
+
+    def test_validate_excerpt_not_found_real_geo(self, validator):
+        """Test validating text that does NOT exist in a real GEO dataset.
+
+        This verifies the validator correctly rejects non-matching text.
+        """
+        result = validator.validate(
+            "This text about zebras and quantum computing is definitely not in any GEO dataset",
+            "GEO:GSE67472",
+        )
+
+        assert result.is_valid is False
+        assert result.severity == ValidationSeverity.ERROR
+        assert "not found" in result.message.lower()
+
+    def test_validate_title_match_real_geo(self, validator):
+        """Test title validation success with real GEO dataset.
+
+        GSE67472 title: "Airway epithelial gene expression in asthma versus healthy controls"
+        """
+        result = validator.validate(
+            "Airway epithelial brushings",  # text that exists in content
+            "GEO:GSE67472",
+            expected_title="Airway epithelial gene expression in asthma versus healthy controls",
+        )
+
+        assert result.is_valid is True
+        assert "title validated" in result.message
+
+    def test_validate_title_mismatch_real_geo(self, validator):
+        """Test title validation failure with real GEO dataset.
+
+        This tests that the validator correctly rejects a wrong title.
+        """
+        result = validator.validate(
+            "Airway epithelial brushings",  # text that exists in content
+            "GEO:GSE67472",
+            expected_title="This is a completely wrong title that does not match",
+        )
+
+        assert result.is_valid is False
+        assert result.severity == ValidationSeverity.ERROR
+        assert "title mismatch" in result.message.lower()
+
+    def test_validate_title_partial_match_real_geo(self, validator):
+        """Test that partial title matches work (case-insensitive, normalized).
+
+        Title validation should be flexible with case and punctuation.
+        """
+        result = validator.validate(
+            "Airway epithelial brushings",
+            "GEO:GSE67472",
+            # Slightly different case/punctuation
+            expected_title="airway epithelial gene expression in asthma versus healthy controls",
+        )
+
+        assert result.is_valid is True
+        assert "title validated" in result.message
+
+    def test_validate_multipart_excerpt_real_geo(self, validator):
+        """Test multi-part quote validation with real GEO dataset.
+
+        Uses ellipsis (...) to match non-contiguous text.
+        """
+        result = validator.validate(
+            "Airway epithelial ... asthma subjects",
+            "GEO:GSE67472",
+        )
+
+        assert result.is_valid is True
+
+    def test_validate_wrong_reference_id(self, validator):
+        """Test validation fails gracefully for nonexistent GEO dataset."""
+        result = validator.validate(
+            "Some text",
+            "GEO:GSE99999999999",
+        )
+
+        assert result.is_valid is False
+        assert result.severity == ValidationSeverity.ERROR
+        assert "could not fetch" in result.message.lower() or "not found" in result.message.lower()


### PR DESCRIPTION
## Summary

- Fix GEO source to convert accessions (GSE/GDS) to numeric UIDs via `esearch` before calling `esummary` (the GDS database requires numeric UIDs, not accession strings)
- Add `--title` option to `validate text` CLI command for validating reference titles
- Add comprehensive tests for GEO source with accession-to-UID conversion mocking
- Add integration test suite for GEO validation workflows
- Update documentation with title validation examples and GEO accession-to-UID explanation

## Test plan

- [x] `just pytest tests/test_sources.py` - All 45 tests pass
- [x] CLI `--title` option shows in help
- [ ] Manual test with real GEO dataset (optional: `pytest -m integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)