### PR TITLE
ci: migrate Claude workflows to claude-code-action@v1 and pin Opus

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,46 +33,29 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
-          
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          # In v1, providing a `prompt` runs in automation mode, which does NOT
+          # post a comment by default. track_progress restores the v0.x
+          # "post the review as a PR comment" behavior and auto-injects PR context.
+          track_progress: true
+
+          # Prompt for the automated review (no @claude mention needed).
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
             - Performance considerations
             - Security concerns
             - Test coverage
-            
+
             Be constructive and helpful in your feedback.
 
-          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
-          
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
-          
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
-          # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
+          # Args passed through to the Claude CLI. Use the `opus` alias rather
+          # than a dated model id so the workflow tracks the current Opus and
+          # won't 404 when a specific version is retired.
+          claude_args: |
+            --model opus
 

--- a/.github/workflows/claude-ontology-review.yml
+++ b/.github/workflows/claude-ontology-review.yml
@@ -35,15 +35,23 @@ jobs:
 
       - name: Run Claude Code Ontology Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (commenting defaults to Claude Sonnet 4)
-          model: "claude-opus-4-1-20250805"
+          # In v1, providing a `prompt` runs in automation mode, which does NOT
+          # post a comment by default. track_progress restores the v0.x
+          # "post the review as a PR comment" behavior and auto-injects PR context.
+          track_progress: true
 
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          # Model is passed through to the Claude CLI via claude_args. Use the
+          # `opus` alias so the workflow tracks the current Opus and won't 404
+          # when a specific dated model id is retired.
+          claude_args: |
+            --model opus
+
+          # Prompt for the automated review (no @claude mention needed)
+          prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
@@ -90,26 +98,4 @@ jobs:
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           use_sticky_comment: true
-          
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
-          
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
-          # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,52 +39,24 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
-        
+        uses: anthropics/claude-code-action@v1
+
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          mcp_config: |
-            {
-              "mcpServers": {
-                "ols": {
-                  "command": "uvx",
-                  "args": [
-                    "ols-mcp"
-                  ]
-                },
-                "sequential-thinking": {
-                  "command": "npx",
-                  "args": [
-                    "-y",
-                    "@modelcontextprotocol/server-sequential-thinking"
-                  ]
-                }
-              }
-            }
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-          
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
-          
+
+          # In v1 the model, MCP servers, and allowed tools are passed through to
+          # the Claude CLI via claude_args (the v0.x model / mcp_config /
+          # allowed_tools inputs were removed). The `opus` alias tracks the
+          # current Opus so this won't 404 when a dated model id is retired.
+          claude_args: |
+            --model opus
+            --mcp-config '{"mcpServers":{"ols":{"command":"uvx","args":["ols-mcp"]},"sequential-thinking":{"command":"npx","args":["-y","@modelcontextprotocol/server-sequential-thinking"]}}}'
+            --allowedTools "Bash(*),FileEdit,Edit,MultiEdit,WebSearch,WebFetch,mcp__ols_mcp__search_all_ontologies,mcp__ols_mcp__get_terms_from_ontology"
+
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
-          
-          # Optional: Trigger when specific user is assigned to an issue
-          # assignee_trigger: "claude-bot"
-          
-          # Optional: Allow Claude to run specific commands
-          allowed_tools: "Bash(*),FileEdit,Edit,MultiEdit,WebSearch,WebFetch,mcp__ols_mcp__search_all_ontologies,mcp__ols_mcp__get_terms_from_ontology"
-          
-          # Optional: Add custom instructions for Claude to customize its behavior for your project
-          # custom_instructions: |
-          #   Follow our coding standards
-          #   Ensure all new code has tests
-          #   Use TypeScript for new files
-          
-          # Optional: Custom environment variables for Claude
-          # claude_env: |
-          #   NODE_ENV: test
 


### PR DESCRIPTION
## Problem

The **Claude Code Review** job has been failing on PRs with:

```
API Error: 404 {"type":"not_found_error","message":"model: claude-sonnet-4-20250514"}
```

The workflows pinned no model, so `anthropics/claude-code-action@beta` fell back to a built-in default model id (`claude-sonnet-4-20250514`) that has since been **retired** → 404 → the step exits 1. It's not a code problem; it's the action defaulting to a dead model. (See e.g. run 27656888640 on PR #49.)

## Change

Migrate the three workflows that use the action off `@beta` onto the stable **`@v1`** line and pin **Opus** explicitly. The v1 input surface changed, so this is more than a version bump:

| Workflow | Changes |
|---|---|
| `claude-code-review.yml` | `@beta`→`@v1`, `direct_prompt`→`prompt`, `claude_args: --model opus`, `track_progress: true` |
| `claude-ontology-review.yml` | same migration; also replaces the also-retired `model: "claude-opus-4-1-20250805"` pin with `--model opus` |
| `claude.yml` (interactive `@claude` bot) | `@beta`→`@v1`; removed `mcp_config`/`allowed_tools` inputs moved into `claude_args` (`--mcp-config`, `--allowedTools`); `--model opus` |

### Notes
- **`--model opus` (alias), not a dated id** — this is the exact failure mode being fixed; the alias always resolves to the current Opus so it won't 404 the next time a version retires. Swap in `claude-opus-4-8` if exact pinning is preferred.
- **`track_progress: true`** restores the v0.x behavior of posting a review comment (in v1, supplying a `prompt` runs automation mode, which doesn't comment by default) and auto-injects PR context.
- Pre-existing quirk left as-is in `claude.yml`: server is named `ols` but `--allowedTools` lists `mcp__ols_mcp__…` (would be `mcp__ols__…`); out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)