### PR TITLE
feat(preprints): add preprint reference support with EPMC full-text route

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,10 +374,36 @@ reference:
 - `PMID:12345678`
 - `12345678` (assumes PMID)
 
-### Coming Soon
+#### Preprints
 
-- **DOI** - `DOI:10.1038/nature12345`
-- **URLs** - Web pages and online documents
+Preprints are supported as first-class references:
+
+```yaml
+reference:
+  id: DOI:10.1101/2024.01.01.573333   # by DOI
+  supporting_text: "the kinase phosphorylates the substrate in vitro"
+```
+
+```yaml
+reference:
+  id: PPR:PPR123456                    # by Europe PMC preprint id
+  supporting_text: "the kinase phosphorylates the substrate in vitro"
+```
+
+**Fetches:**
+- Abstract and metadata (title, authors, server, year, DOI)
+- Full-text body via the Europe PMC `fulltextRepo` PDF route (`epmc_preprint`
+  provider), for the Europe-PMC-ingested subset
+- `is_preprint` / `peer_review_status` flags, so downstream KBs can apply
+  "not sole support" policies
+
+**ID Formats:**
+- `DOI:10.1101/...` (Crossref `posted-content` is detected as a preprint)
+- `PPR:PPR123456` (Europe PMC `SRC:PPR` id)
+- NIH Preprint Pilot preprints carry real PMIDs and resolve via the `PMID:` path
+
+See the [full-text guide](docs/how-to/fetch-full-text-and-pdfs.md#preprints) for
+details and coverage caveats.
 
 ---
 

--- a/docs/how-to/fetch-full-text-and-pdfs.md
+++ b/docs/how-to/fetch-full-text-and-pdfs.md
@@ -21,11 +21,13 @@ The validator tries providers in order until one returns usable full text.
 The default order is:
 
 ```
-pmc → unpaywall → openalex
+pmc → epmc_preprint → unpaywall → openalex
 ```
 
 - **`pmc`** — PubMed Central open-access subset (XML/HTML full text for many
   biomedical articles).
+- **`epmc_preprint`** — Europe PMC preprint body text via the `fulltextRepo`
+  PDF route (see [Preprints](#preprints) below).
 - **`unpaywall`** — Unpaywall open-access lookup by DOI (often a publisher or
   repository PDF).
 - **`openalex`** — OpenAlex open-access location (PDF/HTML).
@@ -43,7 +45,7 @@ your config YAML or on the `ReferenceValidationConfig` object):
 | Key | Default | Description |
 |-----|---------|-------------|
 | `fetch_full_text` | `true` | Attempt to obtain full text via the provider chain when a metadata source does not already return full text. |
-| `full_text_providers` | `[pmc, unpaywall, openalex]` | Ordered list of provider names to try until one yields usable full text. |
+| `full_text_providers` | `[pmc, epmc_preprint, unpaywall, openalex]` | Ordered list of provider names to try until one yields usable full text. |
 | `pdf_backend` | `pypdf` | Name of the PDF text-extraction backend. |
 | `download_pdfs` | `true` | If true, persist downloaded PDFs to the files cache directory. |
 | `full_text_providers_file` | `null` | Optional path to a YAML file defining custom full-text providers. |
@@ -62,11 +64,55 @@ email: you@example.org
 fetch_full_text: true
 full_text_providers:
   - pmc
+  - epmc_preprint
   - unpaywall
   - openalex
 pdf_backend: pypdf
 download_pdfs: true
 ```
+
+## Preprints
+
+Preprints are first-class references. They are increasingly cited for early
+mechanistic findings, but they sit in two distinct universes that need
+different handling:
+
+- **NIH Preprint Pilot** — a subset of preprints carry real PMIDs, so they
+  resolve through the normal `PMID:` path with no special handling.
+- **Europe PMC `SRC:PPR`** — the much larger preprint firehose is DOI-only
+  (no PMIDs). These resolve by DOI through Crossref, or directly by their
+  Europe PMC preprint id using the `PPR:` prefix (e.g. `PPR:PPR123456`).
+
+### Full-text retrieval
+
+Preprint bodies are **not** served by the PMC `fullTextXML` endpoint — even the
+~7% with a PMCID expose only abstract/title/supplementary in PMC, and direct
+`biorxiv.org/...full.pdf` links sit behind a bot challenge. The route that
+works for automated clients is the Europe PMC `fulltextRepo` PDF, used by the
+`epmc_preprint` provider: it resolves a preprint by DOI (or `SRC:PPR` id),
+finds the open `fulltextRepo` PDF URL, and downloads it. The PDF's `%PDF-`
+magic bytes are validated before extraction, so a stale-filename error blob is
+rejected rather than fed to the PDF parser, and the chain falls through
+gracefully.
+
+Coverage note: the `epmc_preprint` route covers the Europe-PMC-ingested
+preprint subset. The newest openRxiv DOIs (prefix `10.64898`) are not yet in
+Europe PMC, so very recent preprints may resolve to metadata only until they
+are ingested.
+
+### Preprint / peer-review status
+
+When a reference is detected as a preprint — via the Crossref `posted-content`
+type or a Europe PMC `SRC:PPR` record — the cached reference records it:
+
+| Field | Description |
+|-------|-------------|
+| `is_preprint` | `true` when the reference is a preprint; left unset otherwise. |
+| `peer_review_status` | `preprint` for preprints; left unset otherwise. |
+
+Downstream knowledge bases can use these fields to apply policies such as "a
+preprint may not be the sole support for a claim". Peer-reviewed papers are
+left unannotated rather than positively asserted as `peer_reviewed`.
 
 ## CLI flag
 
@@ -122,7 +168,7 @@ the text came from. These provenance fields are written alongside the content:
 
 | Field | Description |
 |-------|-------------|
-| `full_text_provider` | Name of the provider that supplied the full text (e.g. `pmc`, `unpaywall`, or a custom name). |
+| `full_text_provider` | Name of the provider that supplied the full text (e.g. `pmc`, `epmc_preprint`, `unpaywall`, or a custom name). |
 | `oa_status` | Open-access status reported by the provider (e.g. `gold`, `green`, `bronze`). |
 | `license` | License of the open-access copy, when known. |
 | `local_pdf_path` | Path (relative to the cache directory) to the downloaded PDF, when one was persisted. |

--- a/docs/how-to/fetch-full-text-and-pdfs.md
+++ b/docs/how-to/fetch-full-text-and-pdfs.md
@@ -107,12 +107,12 @@ type or a Europe PMC `SRC:PPR` record — the cached reference records it:
 
 | Field | Description |
 |-------|-------------|
-| `is_preprint` | `true` when the reference is a preprint; left unset otherwise. |
+| `is_preprint` | `true` for a preprint, `false` when the source authoritatively classifies it as not a preprint (e.g. a Crossref `journal-article`), and unset when the type is unknown. |
 | `peer_review_status` | `preprint` for preprints; left unset otherwise. |
 
 Downstream knowledge bases can use these fields to apply policies such as "a
-preprint may not be the sole support for a claim". Peer-reviewed papers are
-left unannotated rather than positively asserted as `peer_reviewed`.
+preprint may not be the sole support for a claim". A non-preprint is not
+positively asserted as `peer_reviewed`; `peer_review_status` stays unset.
 
 ## CLI flag
 

--- a/src/linkml_reference_validator/etl/fulltext/__init__.py
+++ b/src/linkml_reference_validator/etl/fulltext/__init__.py
@@ -7,6 +7,7 @@ from linkml_reference_validator.etl.fulltext.base import (
 
 # Import providers to register them
 from linkml_reference_validator.etl.fulltext.pmc import PMCFullTextProvider
+from linkml_reference_validator.etl.fulltext.epmc_preprint import EuropePMCPreprintProvider
 from linkml_reference_validator.etl.fulltext.unpaywall import UnpaywallProvider
 from linkml_reference_validator.etl.fulltext.openalex import OpenAlexProvider
 
@@ -14,6 +15,7 @@ __all__ = [
     "FullTextProvider",
     "FullTextProviderRegistry",
     "PMCFullTextProvider",
+    "EuropePMCPreprintProvider",
     "UnpaywallProvider",
     "OpenAlexProvider",
 ]

--- a/src/linkml_reference_validator/etl/fulltext/epmc_preprint.py
+++ b/src/linkml_reference_validator/etl/fulltext/epmc_preprint.py
@@ -49,6 +49,12 @@ class EuropePMCPreprintProvider(FullTextProvider):
     def locate(
         self, ids: ReferenceIdentifiers, config: ReferenceValidationConfig
     ) -> Optional[FullTextLocation]:
+        # Skip the Europe PMC round-trip for records the metadata source already
+        # confirmed are peer-reviewed (is_preprint False). A None ("unknown", e.g.
+        # a PMID or DataCite record) is still attempted.
+        if ids.is_preprint is False:
+            return None
+
         query = self._build_query(ids)
         if query is None:
             return None

--- a/src/linkml_reference_validator/etl/fulltext/epmc_preprint.py
+++ b/src/linkml_reference_validator/etl/fulltext/epmc_preprint.py
@@ -1,0 +1,137 @@
+"""Europe PMC preprint full-text provider.
+
+Preprints (Europe PMC ``SRC:PPR`` records) are not served by the PMC
+``fullTextXML`` endpoint and their bodies are absent from PMC even when a PMCID
+exists. The one route that reliably serves a preprint body is the Europe PMC
+``fulltextRepo`` PDF: every ``SRC:PPR AND HAS_FT:Y`` core record carries a direct
+``/fulltextRepo?pprId=...`` PDF URL in its ``fullTextUrlList``.
+
+This provider resolves that URL from a DOI (or a ``SRC:PPR`` id) and returns it as
+a ``FullTextLocation``. The downstream acquire/extract machinery validates the
+``%PDF-`` magic bytes (a minority of records return a stale-filename error blob),
+so an HTML/error response is rejected rather than fed to the PDF parser.
+"""
+
+import logging
+import time
+from typing import Optional
+
+import requests  # type: ignore
+
+from linkml_reference_validator.models import (
+    FullTextLocation,
+    ReferenceIdentifiers,
+    ReferenceValidationConfig,
+)
+from linkml_reference_validator.etl.fulltext.base import (
+    FullTextProvider,
+    FullTextProviderRegistry,
+)
+
+logger = logging.getLogger(__name__)
+
+_EPMC_SEARCH_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/search"
+_FULLTEXT_REPO_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/fulltextRepo"
+
+
+@FullTextProviderRegistry.register
+class EuropePMCPreprintProvider(FullTextProvider):
+    """Locate preprint full text via the Europe PMC fulltextRepo PDF route.
+
+    Examples:
+        >>> EuropePMCPreprintProvider.name()
+        'epmc_preprint'
+    """
+
+    @classmethod
+    def name(cls) -> str:
+        return "epmc_preprint"
+
+    def locate(
+        self, ids: ReferenceIdentifiers, config: ReferenceValidationConfig
+    ) -> Optional[FullTextLocation]:
+        query = self._build_query(ids)
+        if query is None:
+            return None
+
+        time.sleep(config.rate_limit_delay)
+        params = {
+            "query": query,
+            "format": "json",
+            "resultType": "core",
+            "pageSize": "1",
+            "email": config.email,
+        }
+        response = requests.get(_EPMC_SEARCH_URL, params=params, timeout=30)
+        if response.status_code != 200:
+            logger.debug(f"Europe PMC search returned {response.status_code} for {query}")
+            return None
+
+        result = self._first_ppr_result(response.json())
+        if result is None:
+            return None
+
+        pdf_url = self._extract_pdf_url(result)
+        if not pdf_url:
+            return None
+
+        return FullTextLocation(
+            url=pdf_url,
+            format_hint="pdf",
+            oa_status="green",
+            license=result.get("license"),
+            version="preprint",
+            provider="epmc_preprint",
+        )
+
+    def _build_query(self, ids: ReferenceIdentifiers) -> Optional[str]:
+        """Build a Europe PMC query restricted to the preprint source.
+
+        Examples:
+            >>> p = EuropePMCPreprintProvider()
+            >>> p._build_query(ReferenceIdentifiers(doi="10.1101/x"))
+            'DOI:"10.1101/x" AND SRC:PPR'
+            >>> p._build_query(ReferenceIdentifiers(pprid="PPR42"))
+            'PPR42 AND SRC:PPR'
+            >>> p._build_query(ReferenceIdentifiers(pmid="123")) is None
+            True
+        """
+        if ids.doi:
+            return f'DOI:"{ids.doi}" AND SRC:PPR'
+        if ids.pprid:
+            return f"{ids.pprid} AND SRC:PPR"
+        return None
+
+    def _first_ppr_result(self, data: dict) -> Optional[dict]:
+        """Return the first ``SRC:PPR`` result, or None.
+
+        Restricting to ``source == "PPR"`` guards against a peer-reviewed record
+        sharing the DOI namespace being mistaken for a preprint.
+        """
+        results = data.get("resultList", {}).get("result", [])
+        for result in results:
+            if isinstance(result, dict) and result.get("source") == "PPR":
+                return result
+        return None
+
+    def _extract_pdf_url(self, result: dict) -> Optional[str]:
+        """Find the fulltextRepo PDF URL for a preprint core record.
+
+        Prefers a ``documentStyle == "pdf"`` entry in ``fullTextUrlList``; falls
+        back to constructing the ``fulltextRepo`` URL from the preprint id when the
+        record flags ``hasPDF == "Y"`` but lists no usable PDF entry.
+        """
+        full_text_urls = result.get("fullTextUrlList", {}).get("fullTextUrl", [])
+        for entry in full_text_urls:
+            if not isinstance(entry, dict):
+                continue
+            url = entry.get("url")
+            if not url:
+                continue
+            if entry.get("documentStyle") == "pdf" or "fulltextRepo" in url:
+                return url
+
+        if result.get("hasPDF") == "Y" and result.get("id"):
+            return f"{_FULLTEXT_REPO_URL}?pprId={result['id']}&type=FILE&mimeType=application/pdf"
+
+        return None

--- a/src/linkml_reference_validator/etl/fulltext/epmc_preprint.py
+++ b/src/linkml_reference_validator/etl/fulltext/epmc_preprint.py
@@ -31,7 +31,6 @@ from linkml_reference_validator.etl.fulltext.base import (
 logger = logging.getLogger(__name__)
 
 _EPMC_SEARCH_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/search"
-_FULLTEXT_REPO_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/fulltextRepo"
 
 
 @FullTextProviderRegistry.register
@@ -92,14 +91,14 @@ class EuropePMCPreprintProvider(FullTextProvider):
             >>> p._build_query(ReferenceIdentifiers(doi="10.1101/x"))
             'DOI:"10.1101/x" AND SRC:PPR'
             >>> p._build_query(ReferenceIdentifiers(pprid="PPR42"))
-            'PPR42 AND SRC:PPR'
+            'EXT_ID:PPR42 AND SRC:PPR'
             >>> p._build_query(ReferenceIdentifiers(pmid="123")) is None
             True
         """
         if ids.doi:
             return f'DOI:"{ids.doi}" AND SRC:PPR'
         if ids.pprid:
-            return f"{ids.pprid} AND SRC:PPR"
+            return f"EXT_ID:{ids.pprid} AND SRC:PPR"
         return None
 
     def _first_ppr_result(self, data: dict) -> Optional[dict]:
@@ -117,9 +116,12 @@ class EuropePMCPreprintProvider(FullTextProvider):
     def _extract_pdf_url(self, result: dict) -> Optional[str]:
         """Find the fulltextRepo PDF URL for a preprint core record.
 
-        Prefers a ``documentStyle == "pdf"`` entry in ``fullTextUrlList``; falls
-        back to constructing the ``fulltextRepo`` URL from the preprint id when the
-        record flags ``hasPDF == "Y"`` but lists no usable PDF entry.
+        Returns the ``documentStyle == "pdf"`` entry from ``fullTextUrlList`` (the
+        Europe PMC ``fulltextRepo`` PDF). The full URL must be taken verbatim from
+        the record: the working endpoint includes a per-record ``fileName`` query
+        parameter that cannot be reconstructed from the preprint id alone (a
+        ``fileName``-less request 500s), so a record without a usable PDF entry
+        yields no location rather than a guessed URL.
         """
         full_text_urls = result.get("fullTextUrlList", {}).get("fullTextUrl", [])
         for entry in full_text_urls:
@@ -130,8 +132,5 @@ class EuropePMCPreprintProvider(FullTextProvider):
                 continue
             if entry.get("documentStyle") == "pdf" or "fulltextRepo" in url:
                 return url
-
-        if result.get("hasPDF") == "Y" and result.get("id"):
-            return f"{_FULLTEXT_REPO_URL}?pprId={result['id']}&type=FILE&mimeType=application/pdf"
 
         return None

--- a/src/linkml_reference_validator/etl/identifiers.py
+++ b/src/linkml_reference_validator/etl/identifiers.py
@@ -44,7 +44,7 @@ def build_identifiers(content: ReferenceContent) -> ReferenceIdentifiers:
     """
     prefix, identifier = _split_reference_id(content.reference_id)
 
-    ids = ReferenceIdentifiers(doi=content.doi or None)
+    ids = ReferenceIdentifiers(doi=content.doi or None, is_preprint=content.is_preprint)
 
     if prefix and identifier:
         upper = prefix.upper()

--- a/src/linkml_reference_validator/etl/identifiers.py
+++ b/src/linkml_reference_validator/etl/identifiers.py
@@ -39,6 +39,8 @@ def build_identifiers(content: ReferenceContent) -> ReferenceIdentifiers:
         >>> ids = build_identifiers(ReferenceContent(reference_id="PMID:9", doi="10.1/z"))
         >>> ids.pmid, ids.doi
         ('9', '10.1/z')
+        >>> build_identifiers(ReferenceContent(reference_id="PPR:PPR42")).pprid
+        'PPR42'
     """
     prefix, identifier = _split_reference_id(content.reference_id)
 
@@ -50,6 +52,8 @@ def build_identifiers(content: ReferenceContent) -> ReferenceIdentifiers:
             ids.pmid = identifier
         elif upper == "PMCID":
             ids.pmcid = identifier
+        elif upper == "PPR":
+            ids.pprid = identifier
         elif upper == "DOI" and not ids.doi:
             ids.doi = identifier
         elif prefix.lower() == "url":

--- a/src/linkml_reference_validator/etl/reference_fetcher.py
+++ b/src/linkml_reference_validator/etl/reference_fetcher.py
@@ -492,6 +492,10 @@ class ReferenceFetcher:
             for keyword in reference.keywords:
                 lines.append(f"- {self._quote_yaml_value(keyword)}")
         lines.append(f"content_type: {reference.content_type}")
+        if reference.is_preprint is not None:
+            lines.append(f"is_preprint: {str(reference.is_preprint).lower()}")
+        if reference.peer_review_status:
+            lines.append(f"peer_review_status: {reference.peer_review_status}")
         if reference.full_text_attempted:
             lines.append("full_text_attempted: true")
         if reference.full_text_provider:
@@ -651,6 +655,8 @@ class ReferenceFetcher:
             oa_status=frontmatter.get("oa_status"),
             license=frontmatter.get("license"),
             local_pdf_path=frontmatter.get("local_pdf_path"),
+            is_preprint=frontmatter.get("is_preprint"),
+            peer_review_status=frontmatter.get("peer_review_status"),
             full_text_attempted=bool(frontmatter.get("full_text_attempted", False)),
         )
 

--- a/src/linkml_reference_validator/etl/reference_fetcher.py
+++ b/src/linkml_reference_validator/etl/reference_fetcher.py
@@ -495,7 +495,9 @@ class ReferenceFetcher:
         if reference.is_preprint is not None:
             lines.append(f"is_preprint: {str(reference.is_preprint).lower()}")
         if reference.peer_review_status:
-            lines.append(f"peer_review_status: {reference.peer_review_status}")
+            lines.append(
+                f"peer_review_status: {self._quote_yaml_value(reference.peer_review_status)}"
+            )
         if reference.full_text_attempted:
             lines.append("full_text_attempted: true")
         if reference.full_text_provider:

--- a/src/linkml_reference_validator/etl/sources/__init__.py
+++ b/src/linkml_reference_validator/etl/sources/__init__.py
@@ -24,6 +24,7 @@ from linkml_reference_validator.etl.sources.base import (
 # Import sources to register them
 from linkml_reference_validator.etl.sources.pmid import PMIDSource
 from linkml_reference_validator.etl.sources.doi import DOISource
+from linkml_reference_validator.etl.sources.ppr import PPRSource
 from linkml_reference_validator.etl.sources.file import FileSource
 from linkml_reference_validator.etl.sources.url import URLSource
 from linkml_reference_validator.etl.sources.entrez import (
@@ -50,6 +51,7 @@ __all__ = [
     "ReferenceSourceRegistry",
     "PMIDSource",
     "DOISource",
+    "PPRSource",
     "FileSource",
     "URLSource",
     "GEOSource",

--- a/src/linkml_reference_validator/etl/sources/doi.py
+++ b/src/linkml_reference_validator/etl/sources/doi.py
@@ -140,6 +140,8 @@ class DOISource(ReferenceSource):
             abstract = (abstract + "\n\n" + format_extra_fields_for_content(extra)) if abstract else format_extra_fields_for_content(extra)
             metadata["extra_fields_captured"] = list(extra.keys())
 
+        is_preprint = self._is_crossref_preprint(message)
+
         return ReferenceContent(
             reference_id=f"DOI:{doi}",
             title=title,
@@ -151,7 +153,30 @@ class DOISource(ReferenceSource):
             doi=doi,
             keywords=keywords,
             metadata=metadata,
+            is_preprint=True if is_preprint else None,
+            peer_review_status="preprint" if is_preprint else None,
         )
+
+    def _is_crossref_preprint(self, message: dict) -> bool:
+        """Return True if a Crossref work is a preprint.
+
+        Crossref models preprints as ``type: "posted-content"`` (usually with
+        ``subtype: "preprint"``). This is the authoritative signal; a DOI-prefix
+        heuristic is unreliable because, e.g., the ``10.1101`` prefix also covers
+        peer-reviewed Cold Spring Harbor journals.
+
+        Examples:
+            >>> source = DOISource()
+            >>> source._is_crossref_preprint({"type": "posted-content", "subtype": "preprint"})
+            True
+            >>> source._is_crossref_preprint({"type": "posted-content"})
+            True
+            >>> source._is_crossref_preprint({"type": "journal-article"})
+            False
+        """
+        if message.get("type") == "posted-content":
+            return True
+        return str(message.get("subtype", "")).lower() == "preprint"
 
     def _fetch_from_datacite(
         self, doi: str, config: ReferenceValidationConfig

--- a/src/linkml_reference_validator/etl/sources/doi.py
+++ b/src/linkml_reference_validator/etl/sources/doi.py
@@ -140,7 +140,7 @@ class DOISource(ReferenceSource):
             abstract = (abstract + "\n\n" + format_extra_fields_for_content(extra)) if abstract else format_extra_fields_for_content(extra)
             metadata["extra_fields_captured"] = list(extra.keys())
 
-        is_preprint = self._is_crossref_preprint(message)
+        is_preprint = self._crossref_preprint_status(message)
 
         return ReferenceContent(
             reference_id=f"DOI:{doi}",
@@ -153,30 +153,39 @@ class DOISource(ReferenceSource):
             doi=doi,
             keywords=keywords,
             metadata=metadata,
-            is_preprint=True if is_preprint else None,
+            is_preprint=is_preprint,
             peer_review_status="preprint" if is_preprint else None,
         )
 
-    def _is_crossref_preprint(self, message: dict) -> bool:
-        """Return True if a Crossref work is a preprint.
+    def _crossref_preprint_status(self, message: dict) -> Optional[bool]:
+        """Classify a Crossref work as preprint / not-preprint / unknown.
 
         Crossref models preprints as ``type: "posted-content"`` (usually with
-        ``subtype: "preprint"``). This is the authoritative signal; a DOI-prefix
-        heuristic is unreliable because, e.g., the ``10.1101`` prefix also covers
-        peer-reviewed Cold Spring Harbor journals.
+        ``subtype: "preprint"``). The ``type`` is authoritative, so a known
+        non-preprint type returns ``False`` (recorded so a preprint-specific
+        full-text provider can skip the record without a wasted lookup). Only an
+        entirely typeless record is left ``None`` ("unknown"). A DOI-prefix
+        heuristic is deliberately not used because, e.g., the ``10.1101`` prefix
+        also covers peer-reviewed Cold Spring Harbor journals.
 
         Examples:
             >>> source = DOISource()
-            >>> source._is_crossref_preprint({"type": "posted-content", "subtype": "preprint"})
+            >>> source._crossref_preprint_status({"type": "posted-content", "subtype": "preprint"})
             True
-            >>> source._is_crossref_preprint({"type": "posted-content"})
+            >>> source._crossref_preprint_status({"type": "posted-content"})
             True
-            >>> source._is_crossref_preprint({"type": "journal-article"})
+            >>> source._crossref_preprint_status({"type": "journal-article"})
             False
+            >>> source._crossref_preprint_status({}) is None
+            True
         """
         if message.get("type") == "posted-content":
             return True
-        return str(message.get("subtype", "")).lower() == "preprint"
+        if str(message.get("subtype", "")).lower() == "preprint":
+            return True
+        if message.get("type"):
+            return False
+        return None
 
     def _fetch_from_datacite(
         self, doi: str, config: ReferenceValidationConfig

--- a/src/linkml_reference_validator/etl/sources/ppr.py
+++ b/src/linkml_reference_validator/etl/sources/ppr.py
@@ -71,7 +71,7 @@ class PPRSource(ReferenceSource):
         time.sleep(config.rate_limit_delay)
 
         params = {
-            "query": f"{ppr_id} AND SRC:PPR",
+            "query": f"EXT_ID:{ppr_id} AND SRC:PPR",
             "format": "json",
             "resultType": "core",
             "pageSize": "1",

--- a/src/linkml_reference_validator/etl/sources/ppr.py
+++ b/src/linkml_reference_validator/etl/sources/ppr.py
@@ -77,12 +77,20 @@ class PPRSource(ReferenceSource):
             "pageSize": "1",
             "email": config.email,
         }
-        response = requests.get(_EPMC_SEARCH_URL, params=params, timeout=30)
-        if response.status_code != 200:
-            logger.warning(f"Europe PMC returned {response.status_code} for PPR:{ppr_id}")
+        # External system boundary: a network blip or a non-JSON body must yield a
+        # graceful skip (None) for this one reference, as the PMID and
+        # ClinicalTrials sources do, rather than aborting the whole validation run.
+        try:
+            response = requests.get(_EPMC_SEARCH_URL, params=params, timeout=30)
+            if response.status_code != 200:
+                logger.warning(f"Europe PMC returned {response.status_code} for PPR:{ppr_id}")
+                return None
+            data = response.json()
+        except Exception as exc:
+            logger.warning(f"Failed to fetch PPR:{ppr_id} from Europe PMC: {exc}")
             return None
 
-        result = self._first_ppr_result(response.json())
+        result = self._first_ppr_result(data)
         if result is None:
             logger.warning(f"No Europe PMC preprint found for PPR:{ppr_id}")
             return None

--- a/src/linkml_reference_validator/etl/sources/ppr.py
+++ b/src/linkml_reference_validator/etl/sources/ppr.py
@@ -1,0 +1,151 @@
+"""Preprint (Europe PMC ``SRC:PPR``) reference source.
+
+Resolves a preprint by its Europe PMC preprint id (``PPR:PPR123456``) to metadata
+via the Europe PMC REST search API. The ``SRC:PPR`` universe is the preprint
+firehose: DOI-bearing but without PMIDs, so these records are not reachable
+through the normal PMID path. Records resolved here are always marked as
+preprints (``is_preprint`` / ``peer_review_status``) so downstream knowledge bases
+can apply "not sole support" policies.
+
+Preprint *full text* is fetched separately by the ``epmc_preprint`` full-text
+provider (via the DOI/PPR id crosswalk); this source only supplies metadata and
+the abstract.
+
+Examples:
+    >>> from linkml_reference_validator.etl.sources.ppr import PPRSource
+    >>> PPRSource.prefix()
+    'PPR'
+    >>> PPRSource.can_handle("PPR:PPR123456")
+    True
+    >>> PPRSource.can_handle("DOI:10.1101/x")
+    False
+"""
+
+import logging
+import time
+from typing import Optional
+
+import requests  # type: ignore
+
+from linkml_reference_validator.models import ReferenceContent, ReferenceValidationConfig
+from linkml_reference_validator.etl.sources.base import ReferenceSource, ReferenceSourceRegistry
+
+logger = logging.getLogger(__name__)
+
+_EPMC_SEARCH_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/search"
+
+
+@ReferenceSourceRegistry.register
+class PPRSource(ReferenceSource):
+    """Fetch preprint metadata from Europe PMC by ``SRC:PPR`` id.
+
+    Examples:
+        >>> source = PPRSource()
+        >>> source.prefix()
+        'PPR'
+    """
+
+    @classmethod
+    def prefix(cls) -> str:
+        """Return 'PPR' prefix.
+
+        Examples:
+            >>> PPRSource.prefix()
+            'PPR'
+        """
+        return "PPR"
+
+    def fetch(
+        self, identifier: str, config: ReferenceValidationConfig
+    ) -> Optional[ReferenceContent]:
+        """Fetch preprint metadata for a Europe PMC preprint id.
+
+        Args:
+            identifier: Preprint id (with or without the leading ``PPR``).
+            config: Configuration including rate limiting and email.
+
+        Returns:
+            ReferenceContent marked as a preprint, or None if not found.
+        """
+        ppr_id = self._normalize_id(identifier)
+        time.sleep(config.rate_limit_delay)
+
+        params = {
+            "query": f"{ppr_id} AND SRC:PPR",
+            "format": "json",
+            "resultType": "core",
+            "pageSize": "1",
+            "email": config.email,
+        }
+        response = requests.get(_EPMC_SEARCH_URL, params=params, timeout=30)
+        if response.status_code != 200:
+            logger.warning(f"Europe PMC returned {response.status_code} for PPR:{ppr_id}")
+            return None
+
+        result = self._first_ppr_result(response.json())
+        if result is None:
+            logger.warning(f"No Europe PMC preprint found for PPR:{ppr_id}")
+            return None
+
+        abstract = result.get("abstractText") or None
+        doi = result.get("doi") or None
+        year = str(result.get("pubYear")) if result.get("pubYear") else None
+
+        return ReferenceContent(
+            reference_id=f"PPR:{ppr_id}",
+            title=result.get("title") or None,
+            content=abstract,
+            content_type="abstract_only" if abstract else "unavailable",
+            authors=self._parse_authors(result.get("authorString")),
+            journal=self._extract_journal(result),
+            year=year,
+            doi=doi,
+            is_preprint=True,
+            peer_review_status="preprint",
+        )
+
+    def _normalize_id(self, identifier: str) -> str:
+        """Normalize a preprint id to Europe PMC's ``PPR`` form.
+
+        Examples:
+            >>> source = PPRSource()
+            >>> source._normalize_id("PPR123456")
+            'PPR123456'
+            >>> source._normalize_id("123456")
+            'PPR123456'
+            >>> source._normalize_id("ppr123456")
+            'PPR123456'
+        """
+        stripped = identifier.strip()
+        if stripped.upper().startswith("PPR"):
+            return "PPR" + stripped[3:]
+        return f"PPR{stripped}"
+
+    def _first_ppr_result(self, data: dict) -> Optional[dict]:
+        """Return the first ``SRC:PPR`` result, or None."""
+        results = data.get("resultList", {}).get("result", [])
+        for result in results:
+            if isinstance(result, dict) and result.get("source") == "PPR":
+                return result
+        return None
+
+    def _parse_authors(self, author_string: Optional[str]) -> Optional[list[str]]:
+        """Split a Europe PMC ``authorString`` into individual names.
+
+        Examples:
+            >>> source = PPRSource()
+            >>> source._parse_authors("Smith J, Doe A.")
+            ['Smith J', 'Doe A']
+            >>> source._parse_authors(None) is None
+            True
+        """
+        if not author_string:
+            return None
+        names = [name.strip().rstrip(".").strip() for name in author_string.split(",")]
+        names = [name for name in names if name]
+        return names or None
+
+    def _extract_journal(self, result: dict) -> Optional[str]:
+        """Extract the hosting server name (e.g. bioRxiv) from journalInfo."""
+        journal = result.get("journalInfo", {}).get("journal", {}).get("title")
+        return journal or None

--- a/src/linkml_reference_validator/models.py
+++ b/src/linkml_reference_validator/models.py
@@ -635,6 +635,10 @@ class ReferenceIdentifiers:
     pmcid: Optional[str] = None
     url: Optional[str] = None
     pprid: Optional[str] = None  # Europe PMC preprint id (SRC:PPR), e.g. "PPR123456"
+    # Carried from the metadata source so a preprint-specific provider can skip a
+    # record already known to be peer-reviewed (False) without a wasted lookup.
+    # None means "unknown", which providers must still attempt.
+    is_preprint: Optional[bool] = None
 
 
 @dataclass

--- a/src/linkml_reference_validator/models.py
+++ b/src/linkml_reference_validator/models.py
@@ -462,11 +462,12 @@ class ReferenceValidationConfig(BaseModel):
         ),
     )
     full_text_providers: list[str] = Field(
-        default_factory=lambda: ["pmc", "unpaywall", "openalex"],
+        default_factory=lambda: ["pmc", "epmc_preprint", "unpaywall", "openalex"],
         description=(
             "Ordered list of full-text provider names to try until one yields usable "
-            "full text. Names map to built-in providers (pmc, unpaywall, openalex) or "
-            "custom providers loaded from YAML."
+            "full text. Names map to built-in providers (pmc, epmc_preprint, unpaywall, "
+            "openalex) or custom providers loaded from YAML. The epmc_preprint provider "
+            "fetches preprint body text via the Europe PMC fulltextRepo PDF route."
         ),
     )
     pdf_backend: str = Field(
@@ -625,12 +626,15 @@ class ReferenceIdentifiers:
         '10.1038/x'
         >>> ids.pmcid is None
         True
+        >>> ReferenceIdentifiers(pprid="PPR123456").pprid
+        'PPR123456'
     """
 
     doi: Optional[str] = None
     pmid: Optional[str] = None
     pmcid: Optional[str] = None
     url: Optional[str] = None
+    pprid: Optional[str] = None  # Europe PMC preprint id (SRC:PPR), e.g. "PPR123456"
 
 
 @dataclass
@@ -679,6 +683,16 @@ class ReferenceContent:
         ... )
         >>> len(ref.supplementary_files)
         1
+        >>> ref = ReferenceContent(
+        ...     reference_id="DOI:10.1101/2024.01.01.573333",
+        ...     title="A preprint",
+        ...     is_preprint=True,
+        ...     peer_review_status="preprint",
+        ... )
+        >>> ref.is_preprint
+        True
+        >>> ref.peer_review_status
+        'preprint'
     """
 
     reference_id: str
@@ -697,6 +711,13 @@ class ReferenceContent:
     oa_status: Optional[str] = None
     license: Optional[str] = None
     local_pdf_path: Optional[str] = None
+    # Preprint / peer-review status, surfaced so downstream KBs can apply policies
+    # such as "a preprint may not be the sole support for a claim". Left as None
+    # when the publication type is unknown; only asserted when positively detected
+    # (e.g. Crossref type "posted-content"/subtype "preprint", or a Europe PMC
+    # SRC:PPR record).
+    is_preprint: Optional[bool] = None
+    peer_review_status: Optional[str] = None  # e.g. "preprint", "peer_reviewed"
     # True once the full-text chain has been run to a clean (error-free) conclusion
     # for this record. Distinguishes "the abstract is all that exists" from "we
     # haven't successfully tried yet", so a transient outage isn't cached forever.

--- a/tests/test_doi_preprint.py
+++ b/tests/test_doi_preprint.py
@@ -66,7 +66,7 @@ def test_posted_content_without_subtype_is_marked(mock_get, source, config):
 
 
 @patch("linkml_reference_validator.etl.sources.doi.requests.get")
-def test_journal_article_is_not_marked_preprint(mock_get, source, config):
+def test_journal_article_is_marked_not_preprint(mock_get, source, config):
     mock_get.return_value = _crossref_response(
         {
             "type": "journal-article",
@@ -80,7 +80,24 @@ def test_journal_article_is_not_marked_preprint(mock_get, source, config):
     result = source.fetch("10.1038/s41586-023-12345", config)
 
     assert result is not None
-    # We only positively assert preprint status; peer-reviewed papers are left
-    # unannotated rather than asserted as "peer_reviewed".
+    # Crossref's type is authoritative, so a known non-preprint is recorded as
+    # is_preprint=False (lets the preprint full-text provider skip it). We still
+    # don't positively assert "peer_reviewed" as a review status.
+    assert result.is_preprint is False
+    assert result.peer_review_status is None
+
+
+@patch("linkml_reference_validator.etl.sources.doi.requests.get")
+def test_typeless_crossref_record_leaves_preprint_unknown(mock_get, source, config):
+    mock_get.return_value = _crossref_response(
+        {
+            "title": ["A typeless record"],
+            "published-online": {"date-parts": [[2024]]},
+        }
+    )
+
+    result = source.fetch("10.1234/typeless", config)
+
+    assert result is not None
     assert result.is_preprint is None
     assert result.peer_review_status is None

--- a/tests/test_doi_preprint.py
+++ b/tests/test_doi_preprint.py
@@ -1,0 +1,86 @@
+"""Tests for preprint detection in the DOI (Crossref) source."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from linkml_reference_validator.models import ReferenceValidationConfig
+from linkml_reference_validator.etl.sources.doi import DOISource
+
+
+@pytest.fixture
+def config(tmp_path):
+    return ReferenceValidationConfig(
+        cache_dir=tmp_path / "cache", rate_limit_delay=0.0, email="me@example.org"
+    )
+
+
+@pytest.fixture
+def source():
+    return DOISource()
+
+
+def _crossref_response(message):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"status": "ok", "message": message}
+    return mock_response
+
+
+@patch("linkml_reference_validator.etl.sources.doi.requests.get")
+def test_posted_content_preprint_is_marked(mock_get, source, config):
+    mock_get.return_value = _crossref_response(
+        {
+            "type": "posted-content",
+            "subtype": "preprint",
+            "title": ["A bioRxiv preprint"],
+            "abstract": "<jats:p>Early findings.</jats:p>",
+            "publisher": "Cold Spring Harbor Laboratory",
+            "published-online": {"date-parts": [[2024]]},
+        }
+    )
+
+    result = source.fetch("10.1101/2024.01.01.573333", config)
+
+    assert result is not None
+    assert result.is_preprint is True
+    assert result.peer_review_status == "preprint"
+
+
+@patch("linkml_reference_validator.etl.sources.doi.requests.get")
+def test_posted_content_without_subtype_is_marked(mock_get, source, config):
+    # Some posted-content records omit the explicit "preprint" subtype.
+    mock_get.return_value = _crossref_response(
+        {
+            "type": "posted-content",
+            "title": ["A preprint"],
+            "publisher": "openRxiv",
+            "published-online": {"date-parts": [[2026]]},
+        }
+    )
+
+    result = source.fetch("10.64898/2026.01.01.000001", config)
+
+    assert result is not None
+    assert result.is_preprint is True
+    assert result.peer_review_status == "preprint"
+
+
+@patch("linkml_reference_validator.etl.sources.doi.requests.get")
+def test_journal_article_is_not_marked_preprint(mock_get, source, config):
+    mock_get.return_value = _crossref_response(
+        {
+            "type": "journal-article",
+            "title": ["A peer-reviewed paper"],
+            "abstract": "<jats:p>Results.</jats:p>",
+            "container-title": ["Nature"],
+            "published-print": {"date-parts": [[2023]]},
+        }
+    )
+
+    result = source.fetch("10.1038/s41586-023-12345", config)
+
+    assert result is not None
+    # We only positively assert preprint status; peer-reviewed papers are left
+    # unannotated rather than asserted as "peer_reviewed".
+    assert result.is_preprint is None
+    assert result.peer_review_status is None

--- a/tests/test_epmc_preprint_provider.py
+++ b/tests/test_epmc_preprint_provider.py
@@ -74,6 +74,28 @@ def test_locate_without_doi_or_pprid_returns_none(config):
 
 
 @patch("linkml_reference_validator.etl.fulltext.epmc_preprint.requests.get")
+def test_locate_skips_confirmed_non_preprint_without_network(mock_get, config):
+    # A record the metadata source confirmed is peer-reviewed (is_preprint False)
+    # must short-circuit before any Europe PMC request.
+    loc = EuropePMCPreprintProvider().locate(
+        ReferenceIdentifiers(doi="10.1038/x", is_preprint=False), config
+    )
+    assert loc is None
+    mock_get.assert_not_called()
+
+
+@patch("linkml_reference_validator.etl.fulltext.epmc_preprint.requests.get")
+def test_locate_attempts_when_preprint_status_unknown(mock_get, config):
+    # is_preprint None (e.g. a PMID/DataCite record) is still attempted.
+    mock_get.return_value = _mock_search([_core_result()])
+    loc = EuropePMCPreprintProvider().locate(
+        ReferenceIdentifiers(doi="10.1101/2024.01.01.573333", is_preprint=None), config
+    )
+    assert loc is not None
+    mock_get.assert_called_once()
+
+
+@patch("linkml_reference_validator.etl.fulltext.epmc_preprint.requests.get")
 def test_locate_by_doi_returns_pdf_location(mock_get, config):
     mock_get.return_value = _mock_search([_core_result()])
 

--- a/tests/test_epmc_preprint_provider.py
+++ b/tests/test_epmc_preprint_provider.py
@@ -130,19 +130,17 @@ def test_locate_non_ppr_source_ignored(mock_get, config):
 
 
 @patch("linkml_reference_validator.etl.fulltext.epmc_preprint.requests.get")
-def test_locate_constructs_fulltextrepo_url_when_list_absent(mock_get, config):
-    # Some core records flag hasPDF=Y but omit a usable pdf entry in the list;
-    # fall back to constructing the fulltextRepo URL from the preprint id.
+def test_locate_no_pdf_entry_returns_none(mock_get, config):
+    # The fulltextRepo PDF URL carries a per-record fileName parameter that cannot
+    # be reconstructed from the preprint id (a fileName-less request 500s), so a
+    # record with no usable PDF entry must yield no location, not a guessed URL.
     result = _core_result(fullTextUrlList={"fullTextUrl": []})
     mock_get.return_value = _mock_search([result])
 
     loc = EuropePMCPreprintProvider().locate(
         ReferenceIdentifiers(doi="10.1101/2024.01.01.573333"), config
     )
-    assert loc is not None
-    assert "fulltextRepo" in loc.url
-    assert "PPR123456" in loc.url
-    assert loc.format_hint == "pdf"
+    assert loc is None
 
 
 @patch("linkml_reference_validator.etl.fulltext.epmc_preprint.requests.get")

--- a/tests/test_epmc_preprint_provider.py
+++ b/tests/test_epmc_preprint_provider.py
@@ -1,0 +1,176 @@
+"""Tests for the Europe PMC preprint full-text provider."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from linkml_reference_validator.models import (
+    ReferenceValidationConfig,
+    ReferenceIdentifiers,
+)
+from linkml_reference_validator.etl.fulltext.epmc_preprint import (
+    EuropePMCPreprintProvider,
+)
+
+
+@pytest.fixture
+def config(tmp_path):
+    return ReferenceValidationConfig(
+        cache_dir=tmp_path / "cache", rate_limit_delay=0.0, email="me@example.org"
+    )
+
+
+def _core_result(**overrides):
+    """A representative Europe PMC SRC:PPR core search result."""
+    result = {
+        "id": "PPR123456",
+        "source": "PPR",
+        "doi": "10.1101/2024.01.01.573333",
+        "title": "A mechanistic preprint",
+        "authorString": "Smith J, Doe A.",
+        "pubYear": "2024",
+        "hasPDF": "Y",
+        "fullTextUrlList": {
+            "fullTextUrl": [
+                {
+                    "availability": "Open access",
+                    "availabilityCode": "OA",
+                    "documentStyle": "pdf",
+                    "site": "Europe_PMC",
+                    "url": (
+                        "https://www.ebi.ac.uk/europepmc/webservices/rest/"
+                        "fulltextRepo?pprId=PPR123456&type=FILE&fileName=ppr.pdf"
+                        "&mimeType=application/pdf"
+                    ),
+                },
+                {
+                    "availability": "Open access",
+                    "documentStyle": "html",
+                    "url": "https://europepmc.org/article/PPR/PPR123456",
+                },
+            ]
+        },
+    }
+    result.update(overrides)
+    return result
+
+
+def _mock_search(result_list):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "hitCount": len(result_list),
+        "resultList": {"result": result_list},
+    }
+    return mock_response
+
+
+def test_name():
+    assert EuropePMCPreprintProvider.name() == "epmc_preprint"
+
+
+def test_locate_without_doi_or_pprid_returns_none(config):
+    provider = EuropePMCPreprintProvider()
+    assert provider.locate(ReferenceIdentifiers(pmid="123"), config) is None
+
+
+@patch("linkml_reference_validator.etl.fulltext.epmc_preprint.requests.get")
+def test_locate_by_doi_returns_pdf_location(mock_get, config):
+    mock_get.return_value = _mock_search([_core_result()])
+
+    loc = EuropePMCPreprintProvider().locate(
+        ReferenceIdentifiers(doi="10.1101/2024.01.01.573333"), config
+    )
+
+    assert loc is not None
+    assert loc.url.startswith(
+        "https://www.ebi.ac.uk/europepmc/webservices/rest/fulltextRepo?pprId=PPR123456"
+    )
+    assert loc.format_hint == "pdf"
+    assert loc.provider == "epmc_preprint"
+    assert loc.version == "preprint"
+
+    # The query must restrict to the preprint source so a peer-reviewed
+    # record sharing the DOI namespace is never picked up here.
+    sent_params = mock_get.call_args.kwargs.get("params", {})
+    assert "SRC:PPR" in sent_params.get("query", "")
+    assert "10.1101/2024.01.01.573333" in sent_params.get("query", "")
+
+
+@patch("linkml_reference_validator.etl.fulltext.epmc_preprint.requests.get")
+def test_locate_by_pprid_without_doi(mock_get, config):
+    mock_get.return_value = _mock_search([_core_result()])
+
+    loc = EuropePMCPreprintProvider().locate(
+        ReferenceIdentifiers(pprid="PPR123456"), config
+    )
+
+    assert loc is not None
+    assert loc.format_hint == "pdf"
+    sent_params = mock_get.call_args.kwargs.get("params", {})
+    assert "PPR123456" in sent_params.get("query", "")
+
+
+@patch("linkml_reference_validator.etl.fulltext.epmc_preprint.requests.get")
+def test_locate_no_results_returns_none(mock_get, config):
+    mock_get.return_value = _mock_search([])
+    loc = EuropePMCPreprintProvider().locate(
+        ReferenceIdentifiers(doi="10.1101/x"), config
+    )
+    assert loc is None
+
+
+@patch("linkml_reference_validator.etl.fulltext.epmc_preprint.requests.get")
+def test_locate_non_ppr_source_ignored(mock_get, config):
+    # A non-preprint record must not be treated as a preprint full-text hit.
+    mock_get.return_value = _mock_search([_core_result(source="MED")])
+    loc = EuropePMCPreprintProvider().locate(
+        ReferenceIdentifiers(doi="10.1101/x"), config
+    )
+    assert loc is None
+
+
+@patch("linkml_reference_validator.etl.fulltext.epmc_preprint.requests.get")
+def test_locate_constructs_fulltextrepo_url_when_list_absent(mock_get, config):
+    # Some core records flag hasPDF=Y but omit a usable pdf entry in the list;
+    # fall back to constructing the fulltextRepo URL from the preprint id.
+    result = _core_result(fullTextUrlList={"fullTextUrl": []})
+    mock_get.return_value = _mock_search([result])
+
+    loc = EuropePMCPreprintProvider().locate(
+        ReferenceIdentifiers(doi="10.1101/2024.01.01.573333"), config
+    )
+    assert loc is not None
+    assert "fulltextRepo" in loc.url
+    assert "PPR123456" in loc.url
+    assert loc.format_hint == "pdf"
+
+
+@patch("linkml_reference_validator.etl.fulltext.epmc_preprint.requests.get")
+def test_locate_no_full_text_returns_none(mock_get, config):
+    # No PDF available at all (hasPDF=N, empty list): nothing to fetch.
+    result = _core_result(hasPDF="N", fullTextUrlList={"fullTextUrl": []})
+    mock_get.return_value = _mock_search([result])
+
+    loc = EuropePMCPreprintProvider().locate(
+        ReferenceIdentifiers(doi="10.1101/x"), config
+    )
+    assert loc is None
+
+
+@patch("linkml_reference_validator.etl.fulltext.epmc_preprint.requests.get")
+def test_locate_http_error_returns_none(mock_get, config):
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_get.return_value = mock_response
+
+    loc = EuropePMCPreprintProvider().locate(
+        ReferenceIdentifiers(doi="10.1101/x"), config
+    )
+    assert loc is None
+
+
+def test_registered_in_default_registry():
+    from linkml_reference_validator.etl.fulltext.base import FullTextProviderRegistry
+    import linkml_reference_validator.etl.fulltext  # noqa: F401
+
+    assert FullTextProviderRegistry.get("epmc_preprint") is not None

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -29,3 +29,16 @@ def test_build_from_url_reference():
     content = ReferenceContent(reference_id="url:https://x/y.pdf")
     ids = build_identifiers(content)
     assert ids.url == "https://x/y.pdf"
+
+
+def test_build_from_ppr_reference():
+    content = ReferenceContent(reference_id="PPR:PPR123456")
+    ids = build_identifiers(content)
+    assert ids.pprid == "PPR123456"
+
+
+def test_build_from_ppr_reference_carries_doi_metadata():
+    content = ReferenceContent(reference_id="PPR:PPR123456", doi="10.1101/2024.01.01.573333")
+    ids = build_identifiers(content)
+    assert ids.pprid == "PPR123456"
+    assert ids.doi == "10.1101/2024.01.01.573333"

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -42,3 +42,15 @@ def test_build_from_ppr_reference_carries_doi_metadata():
     ids = build_identifiers(content)
     assert ids.pprid == "PPR123456"
     assert ids.doi == "10.1101/2024.01.01.573333"
+
+
+def test_build_carries_is_preprint_flag():
+    assert build_identifiers(
+        ReferenceContent(reference_id="DOI:10.1/x", is_preprint=True)
+    ).is_preprint is True
+    assert build_identifiers(
+        ReferenceContent(reference_id="DOI:10.1/x", is_preprint=False)
+    ).is_preprint is False
+    assert build_identifiers(
+        ReferenceContent(reference_id="PMID:123")
+    ).is_preprint is None

--- a/tests/test_ppr_source.py
+++ b/tests/test_ppr_source.py
@@ -1,0 +1,115 @@
+"""Tests for the Europe PMC preprint (PPR) reference source."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from linkml_reference_validator.models import ReferenceValidationConfig
+from linkml_reference_validator.etl.sources.ppr import PPRSource
+from linkml_reference_validator.etl.sources.base import ReferenceSourceRegistry
+
+
+@pytest.fixture
+def config(tmp_path):
+    return ReferenceValidationConfig(
+        cache_dir=tmp_path / "cache", rate_limit_delay=0.0, email="me@example.org"
+    )
+
+
+@pytest.fixture
+def source():
+    return PPRSource()
+
+
+def _mock_search(result):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    results = [result] if result is not None else []
+    mock_response.json.return_value = {
+        "hitCount": len(results),
+        "resultList": {"result": results},
+    }
+    return mock_response
+
+
+def _core_result(**overrides):
+    result = {
+        "id": "PPR123456",
+        "source": "PPR",
+        "doi": "10.1101/2024.01.01.573333",
+        "title": "A mechanistic preprint",
+        "authorString": "Smith J, Doe A.",
+        "pubYear": "2024",
+        "abstractText": "We report a mechanistic finding in early form.",
+        "journalInfo": {"journal": {"title": "bioRxiv"}},
+    }
+    result.update(overrides)
+    return result
+
+
+def test_prefix(source):
+    assert source.prefix() == "PPR"
+
+
+def test_can_handle(source):
+    assert source.can_handle("PPR:PPR123456")
+    assert source.can_handle("ppr:PPR123456")
+    assert not source.can_handle("DOI:10.1101/x")
+    assert not source.can_handle("PMID:123")
+
+
+def test_registered_in_registry():
+    assert ReferenceSourceRegistry.get_source("PPR:PPR123456") is PPRSource
+
+
+@patch("linkml_reference_validator.etl.sources.ppr.requests.get")
+def test_fetch_marks_preprint(mock_get, source, config):
+    mock_get.return_value = _mock_search(_core_result())
+
+    result = source.fetch("PPR123456", config)
+
+    assert result is not None
+    assert result.reference_id == "PPR:PPR123456"
+    assert result.title == "A mechanistic preprint"
+    assert result.doi == "10.1101/2024.01.01.573333"
+    assert result.year == "2024"
+    assert result.authors == ["Smith J", "Doe A"]
+    assert result.journal == "bioRxiv"
+    assert result.content_type == "abstract_only"
+    assert "mechanistic finding" in result.content
+    assert result.is_preprint is True
+    assert result.peer_review_status == "preprint"
+
+
+@patch("linkml_reference_validator.etl.sources.ppr.requests.get")
+def test_fetch_without_abstract_is_unavailable(mock_get, source, config):
+    mock_get.return_value = _mock_search(_core_result(abstractText=""))
+
+    result = source.fetch("PPR123456", config)
+
+    assert result is not None
+    assert result.content_type == "unavailable"
+    assert result.is_preprint is True
+
+
+@patch("linkml_reference_validator.etl.sources.ppr.requests.get")
+def test_fetch_no_results_returns_none(mock_get, source, config):
+    mock_get.return_value = _mock_search(None)
+    assert source.fetch("PPR999999", config) is None
+
+
+@patch("linkml_reference_validator.etl.sources.ppr.requests.get")
+def test_fetch_http_error_returns_none(mock_get, source, config):
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_get.return_value = mock_response
+    assert source.fetch("PPR123456", config) is None
+
+
+@patch("linkml_reference_validator.etl.sources.ppr.requests.get")
+def test_fetch_normalizes_bare_numeric_id(mock_get, source, config):
+    # A user may write "PPR:123456" without the "PPR" prefix on the id itself.
+    mock_get.return_value = _mock_search(_core_result())
+    result = source.fetch("123456", config)
+    assert result is not None
+    sent_params = mock_get.call_args.kwargs.get("params", {})
+    assert "PPR123456" in sent_params.get("query", "")

--- a/tests/test_ppr_source.py
+++ b/tests/test_ppr_source.py
@@ -106,6 +106,16 @@ def test_fetch_http_error_returns_none(mock_get, source, config):
 
 
 @patch("linkml_reference_validator.etl.sources.ppr.requests.get")
+def test_fetch_network_exception_returns_none(mock_get, source, config):
+    # A raised network error must degrade gracefully (skip this reference),
+    # not propagate and abort the whole validation run.
+    import requests
+
+    mock_get.side_effect = requests.exceptions.ConnectionError("boom")
+    assert source.fetch("PPR123456", config) is None
+
+
+@patch("linkml_reference_validator.etl.sources.ppr.requests.get")
 def test_fetch_normalizes_bare_numeric_id(mock_get, source, config):
     # A user may write "PPR:123456" without the "PPR" prefix on the id itself.
     mock_get.return_value = _mock_search(_core_result())

--- a/tests/test_reference_fetcher.py
+++ b/tests/test_reference_fetcher.py
@@ -120,6 +120,43 @@ def test_load_from_disk_not_found(fetcher):
     assert result is None
 
 
+def test_save_and_load_preprint_metadata(fetcher, tmp_path):
+    """Preprint status round-trips through the disk cache frontmatter."""
+    ref = ReferenceContent(
+        reference_id="DOI:10.1101/2024.01.01.573333",
+        title="A preprint",
+        content="Early findings.",
+        content_type="abstract_only",
+        doi="10.1101/2024.01.01.573333",
+        is_preprint=True,
+        peer_review_status="preprint",
+    )
+
+    fetcher._save_to_disk(ref)
+    loaded = fetcher._load_from_disk("DOI:10.1101/2024.01.01.573333")
+
+    assert loaded is not None
+    assert loaded.is_preprint is True
+    assert loaded.peer_review_status == "preprint"
+
+
+def test_save_and_load_non_preprint_leaves_status_unset(fetcher, tmp_path):
+    """A record with no preprint status must not gain one via the cache."""
+    ref = ReferenceContent(
+        reference_id="PMID:12345678",
+        title="A paper",
+        content="Results.",
+        content_type="abstract_only",
+    )
+
+    fetcher._save_to_disk(ref)
+    loaded = fetcher._load_from_disk("PMID:12345678")
+
+    assert loaded is not None
+    assert loaded.is_preprint is None
+    assert loaded.peer_review_status is None
+
+
 def test_save_and_load_with_brackets_in_title(fetcher, tmp_path):
     """Test saving and loading reference with brackets in title.
 

--- a/tests/test_validation_config.py
+++ b/tests/test_validation_config.py
@@ -43,7 +43,7 @@ def test_full_text_config_defaults():
 
     config = ReferenceValidationConfig()
     assert config.fetch_full_text is True
-    assert config.full_text_providers == ["pmc", "unpaywall", "openalex"]
+    assert config.full_text_providers == ["pmc", "epmc_preprint", "unpaywall", "openalex"]
     assert config.pdf_backend == "pypdf"
     assert config.download_pdfs is True
 


### PR DESCRIPTION
Make preprints first-class references with the same anti-hallucination
snippet-validation guarantees as published papers.

- Resolve preprints by DOI (Crossref `posted-content` detected as preprint)
  and by Europe PMC `SRC:PPR` id via a new `PPR:` source.
- Fetch preprint body text through the Europe PMC `fulltextRepo` PDF route
  (`epmc_preprint` provider), added to the default full-text chain after `pmc`.
  PDF `%PDF-` magic is validated by the existing acquire/extract machinery, so
  stale-filename error blobs are rejected and the chain falls through.
- Surface `is_preprint` / `peer_review_status` on ReferenceContent (persisted
  in the cache frontmatter) so downstream KBs can apply "not sole support"
  policies; peer-reviewed papers are left unannotated.
- Crosswalk the preprint id (`pprid`) in build_identifiers.

NIH Preprint Pilot preprints carry real PMIDs and continue to resolve through
the existing PMID path unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SxPb8WHvSHJJkwB5njMsZL