### PR TITLE
Reject empty excerpts and fix content extraction bugs

### DIFF
--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -61,8 +61,13 @@ the excerpt being real evidence. Set `min_excerpt_length` to require a minimum:
 
 ```yaml
 # .linkml-reference-validator.yaml
-min_excerpt_length: 20
+validation:
+  min_excerpt_length: 20
 ```
+
+Keep it under `validation:`. A config file that has a `validation:` section
+ignores validation keys placed at the top level — silently, which for an
+opt-in check means it looks enabled while never running.
 
 The check is off by default (`0`), so existing data keeps validating as before.
 Length is measured in **non-whitespace characters of quoted text**:

--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -36,6 +36,23 @@ reference_content = "...The MUC1 oncoprotein blocks nuclear..."
 # Match: "muc1 oncoprotein" found in normalized reference
 ```
 
+**Empty excerpts are rejected:**
+
+An empty or whitespace-only excerpt is always an error, never a pass. The
+empty string is a substring of every document, so a blank excerpt would
+otherwise be reported as verified evidence while quoting nothing at all:
+
+```python
+supporting_text = ""     # or "   ", "\n"
+# ERROR: Supporting text is empty
+```
+
+The check runs before the reference is fetched, and applies even when the
+reference prefix is on the [skip list](../how-to/skip-unsupported-references.md):
+a blank excerpt is a defect in the data regardless of what it cites. An
+excerpt slot that is *absent* is a different matter — whether it is required
+is up to your schema.
+
 ### 3. Ellipsis Handling
 
 When supporting text contains `...`, each part is matched separately:

--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -53,6 +53,29 @@ a blank excerpt is a defect in the data regardless of what it cites. An
 excerpt slot that is *absent* is a different matter — whether it is required
 is up to your schema.
 
+**Minimum excerpt length (optional):**
+
+A blank excerpt is the extreme case. A two-character one is barely better: a
+short string matches almost any paper by chance, so the match succeeds without
+the excerpt being real evidence. Set `min_excerpt_length` to require a minimum:
+
+```yaml
+# .linkml-reference-validator.yaml
+min_excerpt_length: 20
+```
+
+The check is off by default (`0`), so existing data keeps validating as before.
+Length is measured in **non-whitespace characters of quoted text**:
+
+- Whitespace is ignored, so PDF-to-text extraction damage does not change the
+  count — `"t he pro tein"` and `"the protein"` both measure 10.
+- No tokenizing, so chemical nomenclature and other punctuation-dense strings
+  are counted in full — `"2,3-dihydroxybenzoate"` measures 21, not 2 words.
+- Editorial `[brackets]` and `...` separators do not count, since they are
+  never matched against the reference.
+
+Like the blank check, this runs before the reference is fetched.
+
 ### 3. Ellipsis Handling
 
 When supporting text contains `...`, each part is matched separately:

--- a/docs/how-to/repair-validation-errors.md
+++ b/docs/how-to/repair-validation-errors.md
@@ -297,17 +297,25 @@ the reference. This is usually a bug in whatever generated the data (for
 example, a string slice with a backwards range yielding `""`).
 
 Empty excerpts cannot be repaired automatically — there is no text to correct,
-and fuzzy-matching nothing against the reference would invent a quote. They are
-flagged for removal so you can supply the real quote or drop the evidence item.
+and fuzzy-matching nothing against the reference would invent a quote. They
+appear under **INSUFFICIENT EXCERPTS (nothing to verify)** in the report, so
+you can supply the real quote or drop the evidence item.
+
+They are deliberately *not* counted as removals. A removal recommendation means
+"this quote does not match the reference", a verdict reached by comparing the
+two; here no comparison happened. So `removal_count` excludes them and the
+action type is `INSUFFICIENT_EXCERPT`, not `REMOVAL` — worth knowing if you
+script against the report. They do still make `repair data` exit non-zero.
 
 ### "Supporting text is too short"
 
-The excerpt is below the `min_excerpt_length` you configured (off by default;
-see [How It Works](../concepts/how-it-works.md)). A very short excerpt matches
+The excerpt is below the `min_excerpt_length` you configured (off by default,
+and set under `validation:`; see
+[How It Works](../concepts/how-it-works.md)). A very short excerpt matches
 almost any paper by chance, so it is weak evidence even when the match succeeds.
 
-Like empty excerpts, these are flagged for removal rather than repaired: there
-is no way to guess which longer passage the curator meant.
+Like empty excerpts, these report under **INSUFFICIENT EXCERPTS** rather than
+being repaired: there is no way to guess which longer passage the curator meant.
 
 ### "Reference content not available"
 

--- a/docs/how-to/repair-validation-errors.md
+++ b/docs/how-to/repair-validation-errors.md
@@ -112,7 +112,7 @@ Flags text that appears fabricated or hallucinated:
 
 ```
 RECOMMENDED REMOVALS:
-  PMID:34567890 at evidence[2]:
+  PMID:34567890 at evidence[2].supporting_text:
     Similarity: 8%
     Snippet: 'This completely made up text...'
 ```

--- a/docs/how-to/repair-validation-errors.md
+++ b/docs/how-to/repair-validation-errors.md
@@ -300,6 +300,15 @@ Empty excerpts cannot be repaired automatically — there is no text to correct,
 and fuzzy-matching nothing against the reference would invent a quote. They are
 flagged for removal so you can supply the real quote or drop the evidence item.
 
+### "Supporting text is too short"
+
+The excerpt is below the `min_excerpt_length` you configured (off by default;
+see [How It Works](../concepts/how-it-works.md)). A very short excerpt matches
+almost any paper by chance, so it is weak evidence even when the match succeeds.
+
+Like empty excerpts, these are flagged for removal rather than repaired: there
+is no way to guess which longer passage the curator meant.
+
 ### "Reference content not available"
 
 The reference exists but has no retrievable content:

--- a/docs/how-to/repair-validation-errors.md
+++ b/docs/how-to/repair-validation-errors.md
@@ -290,6 +290,16 @@ The supporting text wasn't found in the reference. Possible causes:
 - Wrong PMID
 - AI-generated/hallucinated quote
 
+### "Supporting text is empty"
+
+The excerpt is empty or whitespace-only, so there is nothing to match against
+the reference. This is usually a bug in whatever generated the data (for
+example, a string slice with a backwards range yielding `""`).
+
+Empty excerpts cannot be repaired automatically — there is no text to correct,
+and fuzzy-matching nothing against the reference would invent a quote. They are
+flagged for removal so you can supply the real quote or drop the evidence item.
+
 ### "Reference content not available"
 
 The reference exists but has no retrievable content:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -585,16 +585,16 @@ Repair Report
 ============================================================
 
 HIGH CONFIDENCE FIXES (auto-applicable):
-  PMID:12345678 at evidence[0]:
+  PMID:12345678 at evidence[0].supporting_text:
     Character normalization fix
     'CO2 levels...' → 'CO₂ levels...'
 
 SUGGESTED FIXES (review recommended):
-  PMID:23456789 at evidence[1]:
+  PMID:23456789 at evidence[1].supporting_text:
     Inserted ellipsis between non-contiguous parts
 
 RECOMMENDED REMOVALS (low confidence):
-  PMID:34567890 at evidence[2]:
+  PMID:34567890 at evidence[2].supporting_text:
     Similarity: 8%
     Snippet: 'Fabricated text...'
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -622,6 +622,10 @@ validation:
     geo: GEO
     NCBIGeo: GEO
 
+  # Minimum non-whitespace characters an excerpt must quote.
+  # 0 disables the check; empty excerpts are rejected regardless.
+  min_excerpt_length: 0
+
 repair:
   # Confidence thresholds
   auto_fix_threshold: 0.95

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -385,6 +385,10 @@ validation:
   # Cache directory (relative to config file or absolute)
   cache_dir: ./references_cache
 
+  # Reject excerpts quoting fewer than this many non-whitespace
+  # characters (0 disables; empty excerpts are always rejected)
+  min_excerpt_length: 0
+
   # Custom reference prefix mappings
   reference_prefix_map:
     geo: GEO

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -324,7 +324,12 @@ reference. Both are rejected before the reference is fetched.
 **Symptom:**
 
 The first run after upgrading re-fetches references that were already cached,
-and logs lines like:
+so it is slower and does more network traffic than usual. Run with `-v` to see
+why — the explanation is logged at INFO level, which only `-v` turns on:
+
+```bash
+linkml-reference-validator validate data.yaml -v
+```
 
 ```
 Ignoring cache entry for PMID:30598549 written by an older extractor;
@@ -344,13 +349,31 @@ re-fetched the next time a validation needs them.
 
 Nothing is deleted, and entries are refreshed one at a time as they are used
 rather than in a single sweep. `cache export` and the Zotero enrichment read
-older entries unchanged — only validation re-fetches them.
+older entries unchanged — only validation re-fetches them. The refresh applies
+to every cache entry, however it was populated, so a cache you pre-fetched
+deliberately will be rebuilt too.
 
 **If you would rather refresh one immediately:**
 
 ```bash
 linkml-reference-validator cache reference PMID:30598549 --force
 ```
+
+**If you are offline:**
+
+The older copy is used rather than lost. When the reference cannot be
+re-fetched — no network, a provider outage, a withdrawn record — validation
+falls back to what is on disk and warns:
+
+```
+Could not re-fetch PMID:30598549; using the cache entry written by an older
+extractor. Its text may still contain the errors this version fixes.
+```
+
+Validation then proceeds against that older text, so a snippet may be rejected
+for the reasons above. The entry is left stale rather than rewritten, so the
+next run that can reach the source refreshes it properly. This warning is
+printed without `-v`.
 
 ### Title validation failed
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -319,26 +319,37 @@ An excerpt that is empty or whitespace-only (`supporting_text: ""`) reports the
 same way, and for the same reason: there is nothing to check against the
 reference. Both are rejected before the reference is fetched.
 
-### Correct quotes rejected after upgrading
+### Cached references re-fetched after upgrading
 
 **Symptom:**
 
-Snippets you know are correct are rejected, and the cached reference is far
-smaller than the article it came from.
+The first run after upgrading re-fetches references that were already cached,
+and logs lines like:
+
+```
+Ignoring cache entry for PMID:30598549 written by an older extractor;
+it will be re-fetched and rewritten
+```
 
 **Cause:**
 
+This is deliberate, and it is a one-off per reference. Cache entries record
+which extractor wrote them (`extractor_version` in the file's frontmatter).
 Versions before the extractor fixes discarded some full-text articles and
-cached a short PMC placeholder page in their place, labelled as full text.
-Fixing the extractors does not rewrite what is already cached.
+cached a short PMC placeholder in their place, labelled as full text, and
+welded text across inline markup — so entries written then hold content that
+would reject correct snippets. Fixing the extractors cannot rewrite what they
+already wrote, so entries from before the fix are treated as absent and
+re-fetched the next time a validation needs them.
 
-**Solution:**
+Nothing is deleted, and entries are refreshed one at a time as they are used
+rather than in a single sweep. `cache export` and the Zotero enrichment read
+older entries unchanged — only validation re-fetches them.
 
-Delete the affected entries from your cache directory (`references_cache/` by
-default) and re-run validation, which re-fetches them:
+**If you would rather refresh one immediately:**
 
 ```bash
-rm references_cache/PMID_30598549.md   # or remove the whole directory
+linkml-reference-validator cache reference PMID:30598549 --force
 ```
 
 ### Title validation failed

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -292,11 +292,12 @@ text = "Your quote here"
 print(normalize_text(text))
 ```
 
-### Query is empty after removing brackets
+### Supporting text is empty once brackets and separators are removed
 
 **Symptom:**
 ```
-Error: Query is empty after removing brackets
+Error: Supporting text is empty once editorial brackets and '...' separators
+are removed: it quotes nothing from the reference
 Supporting text: "[editorial note]"
 ```
 
@@ -312,6 +313,32 @@ supporting_text: "[sic]"
 
 # Correct
 supporting_text: "protein functions in cells [sic]"
+```
+
+An excerpt that is empty or whitespace-only (`supporting_text: ""`) reports the
+same way, and for the same reason: there is nothing to check against the
+reference. Both are rejected before the reference is fetched.
+
+### Correct quotes rejected after upgrading
+
+**Symptom:**
+
+Snippets you know are correct are rejected, and the cached reference is far
+smaller than the article it came from.
+
+**Cause:**
+
+Versions before the extractor fixes discarded some full-text articles and
+cached a short PMC placeholder page in their place, labelled as full text.
+Fixing the extractors does not rewrite what is already cached.
+
+**Solution:**
+
+Delete the affected entries from your cache directory (`references_cache/` by
+default) and re-run validation, which re-fetches them:
+
+```bash
+rm references_cache/PMID_30598549.md   # or remove the whole directory
 ```
 
 ### Title validation failed

--- a/docs/tutorials/complete-workflow.md
+++ b/docs/tutorials/complete-workflow.md
@@ -482,7 +482,7 @@ annotations:
 The repair command will flag for removal:
 ```
 RECOMMENDED REMOVALS (low confidence):
-  PMID:16888623 at evidence[0]:
+  PMID:16888623 at evidence[0].supporting_text:
     Similarity: 5%
     Snippet: 'completely fabricated text that doesn't exist'
     Action: Remove or find correct reference

--- a/src/linkml_reference_validator/cli/repair.py
+++ b/src/linkml_reference_validator/cli/repair.py
@@ -178,7 +178,11 @@ def data_command(
             typer.echo(f"  Applied {report.auto_fixed_count} auto-fix(es)")
 
     # Exit with appropriate code
-    if report.removal_count > 0 or report.unverifiable_count > 0:
+    if (
+        report.removal_count > 0
+        or report.unverifiable_count > 0
+        or report.insufficient_excerpt_count > 0
+    ):
         typer.echo("\n⚠ Manual review required for some items")
         raise typer.Exit(1)
     elif report.suggested_count > 0:

--- a/src/linkml_reference_validator/cli/repair.py
+++ b/src/linkml_reference_validator/cli/repair.py
@@ -312,6 +312,39 @@ def _load_repair_config(config_file: Optional[Path]) -> RepairConfig:
     return RepairConfig()
 
 
+def _excerpt_key(d: dict) -> Optional[str]:
+    """Return the key holding this evidence item's excerpt, if any.
+
+    Prefers a usable quote, but falls back to a blank one when that is all
+    there is: blank excerpts must be reported, not dropped. Used by both
+    extraction and write-back so a repair cannot land in a different field
+    than the quote came from.
+
+    Args:
+        d: A candidate evidence item
+
+    Returns:
+        "supporting_text", "snippet", or None if neither holds a string
+
+    Examples:
+        >>> _excerpt_key({"supporting_text": "a quote"})
+        'supporting_text'
+        >>> _excerpt_key({"supporting_text": "", "snippet": "a quote"})
+        'snippet'
+        >>> _excerpt_key({"supporting_text": ""})
+        'supporting_text'
+        >>> _excerpt_key({"reference": "PMID:1"}) is None
+        True
+    """
+    present = [
+        key for key in ("supporting_text", "snippet") if isinstance(d.get(key), str)
+    ]
+    for key in present:
+        if d[key].strip():
+            return key
+    return present[0] if present else None
+
+
 def _extract_evidence_items(
     data: dict,
     target_class: Optional[str],
@@ -336,21 +369,11 @@ def _extract_evidence_items(
         # Look for evidence patterns
         if isinstance(d, dict):
             # Direct evidence item pattern
-            if "supporting_text" in d or "snippet" in d:
-                # Prefer a usable quote, but keep a blank one when that is all
-                # there is: blank excerpts must be reported, not dropped.
-                candidates: list[str] = []
-                for text_key in ("supporting_text", "snippet"):
-                    text_value = d.get(text_key)
-                    if isinstance(text_value, str):
-                        candidates.append(text_value)
-                text = next(
-                    (c for c in candidates if c.strip()),
-                    candidates[0] if candidates else None,
-                )
+            text_key = _excerpt_key(d)
+            if text_key is not None:
                 ref = d.get("reference") or d.get("reference_id")
-                if text is not None and ref:
-                    items.append((text, ref, path))
+                if ref:
+                    items.append((d[text_key], ref, path))
 
             # Look for evidence list
             for key in ["evidence", "supporting_evidence", "annotations"]:
@@ -410,11 +433,14 @@ def _apply_repairs_to_data(
 
         if isinstance(d, dict):
             # Check if this item needs repair
-            if "supporting_text" in d or "snippet" in d:
-                text_key = "supporting_text" if "supporting_text" in d else "snippet"
-                if path in repairs_by_path:
-                    d[text_key] = repairs_by_path[path]
-                    changes_made = True
+            # Same key the quote was read from. Choosing independently here
+            # let a repair of the snippet be written into supporting_text,
+            # leaving the snippet wrong and inventing a quote in a field that
+            # never had one.
+            text_key = _excerpt_key(d)
+            if text_key is not None and path in repairs_by_path:
+                d[text_key] = repairs_by_path[path]
+                changes_made = True
 
             # Recurse
             for key in ["evidence", "supporting_evidence", "annotations"]:

--- a/src/linkml_reference_validator/cli/repair.py
+++ b/src/linkml_reference_validator/cli/repair.py
@@ -323,9 +323,19 @@ def _extract_evidence_items(
         if isinstance(d, dict):
             # Direct evidence item pattern
             if "supporting_text" in d or "snippet" in d:
-                text = d.get("supporting_text") or d.get("snippet")
+                # Prefer a usable quote, but keep a blank one when that is all
+                # there is: blank excerpts must be reported, not dropped.
+                candidates: list[str] = []
+                for text_key in ("supporting_text", "snippet"):
+                    text_value = d.get(text_key)
+                    if isinstance(text_value, str):
+                        candidates.append(text_value)
+                text = next(
+                    (c for c in candidates if c.strip()),
+                    candidates[0] if candidates else None,
+                )
                 ref = d.get("reference") or d.get("reference_id")
-                if text and ref:
+                if text is not None and ref:
                     items.append((text, ref, path))
 
             # Look for evidence list

--- a/src/linkml_reference_validator/cli/repair.py
+++ b/src/linkml_reference_validator/cli/repair.py
@@ -324,6 +324,11 @@ def _excerpt_keys(d: dict) -> list[str]:
     the reported path, so a repair cannot land in a different field than the
     quote came from.
 
+    An item that stores the same quote under both keys is therefore checked and
+    reported once per key. That is the honest reading - both fields are being
+    validated - and it costs no extra fetching, since the reference is served
+    from the in-process cache the second time.
+
     Args:
         d: A candidate evidence item
 

--- a/src/linkml_reference_validator/cli/repair.py
+++ b/src/linkml_reference_validator/cli/repair.py
@@ -13,7 +13,7 @@ import typer
 from ruamel.yaml import YAML
 from typing_extensions import Annotated
 
-from linkml_reference_validator.models import RepairConfig
+from linkml_reference_validator.models import RepairActionType, RepairConfig
 from linkml_reference_validator.validation.repairer import SupportingTextRepairer
 
 from .shared import (
@@ -246,7 +246,17 @@ def text_command(
         typer.echo(f"  ✗ Could not repair: {result.message}")
         for action in result.actions:
             typer.echo(f"    Suggestion: {action.action_type.value}")
-            typer.echo(f"    Confidence: {action.confidence.value} ({action.similarity_score*100:.0f}%)")
+            # No percentage for excerpts that were never compared: a score of
+            # 0% would read as "checked against the reference and matched
+            # nothing", which is the misreading the separate action type
+            # exists to prevent. format_report omits it for the same reason.
+            if action.action_type == RepairActionType.INSUFFICIENT_EXCERPT:
+                typer.echo(f"    Confidence: {action.confidence.value}")
+            else:
+                typer.echo(
+                    f"    Confidence: {action.confidence.value} "
+                    f"({action.similarity_score*100:.0f}%)"
+                )
             if action.repaired_text:
                 typer.echo(f"    Best match: {action.repaired_text[:80]}...")
 

--- a/src/linkml_reference_validator/cli/repair.py
+++ b/src/linkml_reference_validator/cli/repair.py
@@ -312,37 +312,35 @@ def _load_repair_config(config_file: Optional[Path]) -> RepairConfig:
     return RepairConfig()
 
 
-def _excerpt_key(d: dict) -> Optional[str]:
-    """Return the key holding this evidence item's excerpt, if any.
+def _excerpt_keys(d: dict) -> list[str]:
+    """Return every key holding an excerpt on this evidence item.
 
-    Prefers a usable quote, but falls back to a blank one when that is all
-    there is: blank excerpts must be reported, not dropped. Used by both
-    extraction and write-back so a repair cannot land in a different field
-    than the quote came from.
+    All of them, not the best of them. The LinkML plugin iterates each excerpt
+    field and checks it, so picking one key here left the second quote on an
+    item silently unvalidated and unrepaired. A blank excerpt alongside a real
+    one is still a defect and is still reported.
+
+    Used by both extraction and write-back, and the excerpt key is carried in
+    the reported path, so a repair cannot land in a different field than the
+    quote came from.
 
     Args:
         d: A candidate evidence item
 
     Returns:
-        "supporting_text", "snippet", or None if neither holds a string
+        The excerpt keys present as strings, in a stable order
 
     Examples:
-        >>> _excerpt_key({"supporting_text": "a quote"})
-        'supporting_text'
-        >>> _excerpt_key({"supporting_text": "", "snippet": "a quote"})
-        'snippet'
-        >>> _excerpt_key({"supporting_text": ""})
-        'supporting_text'
-        >>> _excerpt_key({"reference": "PMID:1"}) is None
-        True
+        >>> _excerpt_keys({"supporting_text": "a quote"})
+        ['supporting_text']
+        >>> _excerpt_keys({"supporting_text": "", "snippet": "a quote"})
+        ['supporting_text', 'snippet']
+        >>> _excerpt_keys({"reference": "PMID:1"})
+        []
     """
-    present = [
+    return [
         key for key in ("supporting_text", "snippet") if isinstance(d.get(key), str)
     ]
-    for key in present:
-        if d[key].strip():
-            return key
-    return present[0] if present else None
 
 
 def _extract_evidence_items(
@@ -369,11 +367,11 @@ def _extract_evidence_items(
         # Look for evidence patterns
         if isinstance(d, dict):
             # Direct evidence item pattern
-            text_key = _excerpt_key(d)
-            if text_key is not None:
-                ref = d.get("reference") or d.get("reference_id")
-                if ref:
-                    items.append((d[text_key], ref, path))
+            ref = d.get("reference") or d.get("reference_id")
+            if ref:
+                for text_key in _excerpt_keys(d):
+                    key_path = f"{path}.{text_key}" if path else text_key
+                    items.append((d[text_key], ref, key_path))
 
             # Look for evidence list
             for key in ["evidence", "supporting_evidence", "annotations"]:
@@ -433,14 +431,15 @@ def _apply_repairs_to_data(
 
         if isinstance(d, dict):
             # Check if this item needs repair
-            # Same key the quote was read from. Choosing independently here
-            # let a repair of the snippet be written into supporting_text,
-            # leaving the snippet wrong and inventing a quote in a field that
-            # never had one.
-            text_key = _excerpt_key(d)
-            if text_key is not None and path in repairs_by_path:
-                d[text_key] = repairs_by_path[path]
-                changes_made = True
+            # Keyed by the same path extraction reported, which names the
+            # excerpt field. Choosing a key independently here let a repair of
+            # the snippet be written into supporting_text, leaving the snippet
+            # wrong and inventing a quote in a field that never had one.
+            for text_key in _excerpt_keys(d):
+                key_path = f"{path}.{text_key}" if path else text_key
+                if key_path in repairs_by_path:
+                    d[text_key] = repairs_by_path[key_path]
+                    changes_made = True
 
             # Recurse
             for key in ["evidence", "supporting_evidence", "annotations"]:

--- a/src/linkml_reference_validator/etl/extract/__init__.py
+++ b/src/linkml_reference_validator/etl/extract/__init__.py
@@ -4,10 +4,16 @@ from linkml_reference_validator.etl.extract.base import Extractor, ExtractorRegi
 
 # Import extractors to register them
 from linkml_reference_validator.etl.extract.html import HTMLExtractor
-from linkml_reference_validator.etl.extract.xml import XMLExtractor
+from linkml_reference_validator.etl.extract.xml import (
+    MAX_STUB_NOTICE_CHARS,
+    MIN_FULLTEXT_CHARS,
+    XMLExtractor,
+)
 from linkml_reference_validator.etl.extract.pdf import PDFExtractor
 
 __all__ = [
+    "MAX_STUB_NOTICE_CHARS",
+    "MIN_FULLTEXT_CHARS",
     "Extractor",
     "ExtractorRegistry",
     "HTMLExtractor",

--- a/src/linkml_reference_validator/etl/extract/__init__.py
+++ b/src/linkml_reference_validator/etl/extract/__init__.py
@@ -1,4 +1,12 @@
-"""Content extractors (PDF, HTML, XML)."""
+"""Content extractors (PDF, HTML, XML).
+
+Changing what these produce for the same input does not rewrite the text they
+already wrote to the reference cache, which is served in preference to a fetch.
+When a change means previously cached text is *wrong* rather than merely older,
+bump ``EXTRACTOR_CACHE_VERSION`` in
+:mod:`linkml_reference_validator.etl.reference_fetcher` so existing entries are
+re-fetched instead of keeping the old output forever.
+"""
 
 from linkml_reference_validator.etl.extract.base import Extractor, ExtractorRegistry
 

--- a/src/linkml_reference_validator/etl/extract/__init__.py
+++ b/src/linkml_reference_validator/etl/extract/__init__.py
@@ -5,14 +5,12 @@ from linkml_reference_validator.etl.extract.base import Extractor, ExtractorRegi
 # Import extractors to register them
 from linkml_reference_validator.etl.extract.html import HTMLExtractor
 from linkml_reference_validator.etl.extract.xml import (
-    MAX_STUB_NOTICE_CHARS,
     MIN_FULLTEXT_CHARS,
     XMLExtractor,
 )
 from linkml_reference_validator.etl.extract.pdf import PDFExtractor
 
 __all__ = [
-    "MAX_STUB_NOTICE_CHARS",
     "MIN_FULLTEXT_CHARS",
     "Extractor",
     "ExtractorRegistry",

--- a/src/linkml_reference_validator/etl/extract/base.py
+++ b/src/linkml_reference_validator/etl/extract/base.py
@@ -10,7 +10,7 @@ Examples:
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Optional, Union
 
 logger = logging.getLogger(__name__)
 
@@ -28,8 +28,16 @@ class Extractor(ABC):
         ...
 
     @abstractmethod
-    def extract(self, data: bytes, *, content_type: Optional[str] = None) -> Optional[str]:
-        """Extract plain text from ``data``; return None if nothing usable."""
+    def extract(
+        self, data: Union[bytes, str], *, content_type: Optional[str] = None
+    ) -> Optional[str]:
+        """Extract plain text from ``data``; return None if nothing usable.
+
+        Accepts ``str`` as well as ``bytes`` because some sources hand back
+        already-decoded text (Entrez returns a text handle). Markup parsers
+        take either and handle the encoding declaration correctly in both
+        cases; re-encoding such text before passing it in does not.
+        """
         ...
 
 

--- a/src/linkml_reference_validator/etl/extract/html.py
+++ b/src/linkml_reference_validator/etl/extract/html.py
@@ -94,9 +94,12 @@ class HTMLExtractor(Extractor):
     def _extract_scope(self, scope: Tag) -> Optional[str]:
         """Extract text from a region this extractor is free to modify.
 
+        For callers that own the tree and do not mind it being edited.
         Separated from :meth:`extract_scope` so the copy is paid for only
         where it buys something: a caller-owned tag. ``extract`` parses and
-        discards its own soup, so it enters here directly.
+        discards its own soup, so it enters here directly. Anything reaching
+        for this instead of the public method is opting out of that
+        protection deliberately.
         """
         # Dropped here rather than in extract(), because the PMC paths enter
         # through this method and a JSON-LD blob or stylesheet landing in

--- a/src/linkml_reference_validator/etl/extract/html.py
+++ b/src/linkml_reference_validator/etl/extract/html.py
@@ -51,7 +51,10 @@ class HTMLExtractor(Extractor):
     ) -> Optional[str]:
         soup = BeautifulSoup(data, "html.parser")
         region = soup.find("article") or soup.find("main")
-        return self.extract_scope(region if region is not None else soup)
+        # Straight to the private form: this soup was parsed here and is
+        # discarded here, so the defensive copy extract_scope makes for
+        # caller-owned tags would protect nobody and cost a full tree walk.
+        return self._extract_scope(region if region is not None else soup)
 
     def extract_scope(self, scope: Tag) -> Optional[str]:
         """Extract text from an already-selected region of parsed markup.
@@ -86,8 +89,15 @@ class HTMLExtractor(Extractor):
         # reparse this method replaced (measured ~14ms vs ~24ms on a 76 KB
         # body), and negligible beside the network fetch that produced the
         # markup - so purity here costs nothing that matters.
-        scope = copy.copy(scope)
+        return self._extract_scope(copy.copy(scope))
 
+    def _extract_scope(self, scope: Tag) -> Optional[str]:
+        """Extract text from a region this extractor is free to modify.
+
+        Separated from :meth:`extract_scope` so the copy is paid for only
+        where it buys something: a caller-owned tag. ``extract`` parses and
+        discards its own soup, so it enters here directly.
+        """
         # Dropped here rather than in extract(), because the PMC paths enter
         # through this method and a JSON-LD blob or stylesheet landing in
         # cached article text would corrupt every snippet checked against it.

--- a/src/linkml_reference_validator/etl/extract/html.py
+++ b/src/linkml_reference_validator/etl/extract/html.py
@@ -17,10 +17,16 @@ class HTMLExtractor(Extractor):
     Prefers an ``<article>`` or main content region; falls back to all paragraph
     text, then to the whole document text.
 
+    Whitespace around inline markup is preserved, so text spanning italicised
+    gene symbols survives extraction intact.
+
     Examples:
         >>> html = b"<html><body><p>Hi</p></body></html>"
         >>> HTMLExtractor().extract(html)
         'Hi'
+        >>> genes = b"<html><body><p>near (<i>GUSB</i>, <i>GRN</i>) here</p></body></html>"
+        >>> HTMLExtractor().extract(genes)
+        'near (GUSB, GRN) here'
     """
 
     @classmethod
@@ -38,8 +44,15 @@ class HTMLExtractor(Extractor):
 
         paragraphs = scope.find_all("p")
         if paragraphs:
-            text = "\n\n".join(p.get_text(strip=True) for p in paragraphs if p.get_text(strip=True))
-            if text.strip():
+            # get_text() with no arguments, deliberately: strip=True would trim
+            # every markup-delimited run before joining them, welding words to
+            # their neighbours across inline tags. "(<i>GUSB</i>, <i>GRN</i>,
+            # and <i>NEU1</i>)" became "(GUSB,GRN, andNEU1)", breaking every
+            # curated snippet that spans an italicised gene symbol. Trimming
+            # the finished paragraph instead keeps the source's own spacing.
+            texts = (p.get_text().strip() for p in paragraphs)
+            text = "\n\n".join(t for t in texts if t)
+            if text:
                 return text
 
         text = scope.get_text(separator="\n", strip=True)

--- a/src/linkml_reference_validator/etl/extract/html.py
+++ b/src/linkml_reference_validator/etl/extract/html.py
@@ -48,10 +48,6 @@ class HTMLExtractor(Extractor):
         self, data: Union[bytes, str], *, content_type: Optional[str] = None
     ) -> Optional[str]:
         soup = BeautifulSoup(data, "html.parser")
-
-        for tag in soup(["script", "style"]):
-            tag.decompose()
-
         region = soup.find("article") or soup.find("main")
         return self.extract_scope(region if region is not None else soup)
 
@@ -79,6 +75,15 @@ class HTMLExtractor(Extractor):
             >>> HTMLExtractor().extract_scope(region)
             'near (GUSB, GRN) here'
         """
+        # Dropped here rather than in extract(), because the PMC paths enter
+        # through this method and a JSON-LD blob or stylesheet landing in
+        # cached article text would corrupt every snippet checked against it.
+        # bs4's get_text() also skips Script/Stylesheet strings by default,
+        # but that is a library default to rely on, not a guarantee this
+        # extractor makes.
+        for tag in scope(["script", "style"]):
+            tag.decompose()
+
         # Before either branch, so both agree: <br> carries no text of its own,
         # so bare get_text() would weld the lines it separates into
         # "Line oneLine two" - the same welding this extractor exists to avoid.

--- a/src/linkml_reference_validator/etl/extract/html.py
+++ b/src/linkml_reference_validator/etl/extract/html.py
@@ -94,7 +94,7 @@ class HTMLExtractor(Extractor):
         # bs4's get_text() also skips Script/Stylesheet strings by default,
         # but that is a library default to rely on, not a guarantee this
         # extractor makes.
-        for tag in scope(["script", "style"]):
+        for tag in scope.find_all(["script", "style"]):
             tag.decompose()
 
         # Before either branch, so both agree: <br> carries no text of its own,

--- a/src/linkml_reference_validator/etl/extract/html.py
+++ b/src/linkml_reference_validator/etl/extract/html.py
@@ -1,9 +1,10 @@
 """HTML content extractor."""
 
+import copy
 import logging
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
-from bs4 import BeautifulSoup  # type: ignore
+from bs4 import BeautifulSoup, Tag  # type: ignore
 
 from linkml_reference_validator.etl.extract.base import Extractor, ExtractorRegistry
 
@@ -23,10 +24,11 @@ BLOCK_LEVEL_TAGS = (
 
 @ExtractorRegistry.register
 class HTMLExtractor(Extractor):
-    """Extract readable text from HTML bytes.
+    """Extract readable text from HTML markup, as bytes or as a string.
 
     Prefers an ``<article>`` or main content region; falls back to all paragraph
-    text, then to the whole document text.
+    text, then to the whole document text. Callers holding an already-parsed
+    region of their own use :meth:`extract_scope` instead.
 
     Whitespace around inline markup is preserved, so text spanning italicised
     gene symbols survives extraction intact.
@@ -51,7 +53,7 @@ class HTMLExtractor(Extractor):
         region = soup.find("article") or soup.find("main")
         return self.extract_scope(region if region is not None else soup)
 
-    def extract_scope(self, scope: Any) -> Optional[str]:
+    def extract_scope(self, scope: Tag) -> Optional[str]:
         """Extract text from an already-selected region of parsed markup.
 
         Callers that have chosen their own region - a PMC ``div.article-body``,
@@ -59,6 +61,11 @@ class HTMLExtractor(Extractor):
         ``extract`` would parse the whole body a second time, and would re-run
         the ``<article>``/``<main>`` selection *inside* a region the caller had
         already settled, silently narrowing to a nested one.
+
+        The caller's tag is left untouched: extraction needs to strip markup
+        and mark block boundaries, and doing that in place would edit a
+        document the caller still holds, as well as making a second call on
+        the same region return different text from the first.
 
         Args:
             scope: A BeautifulSoup tag or soup to take the text of
@@ -75,6 +82,12 @@ class HTMLExtractor(Extractor):
             >>> HTMLExtractor().extract_scope(region)
             'near (GUSB, GRN) here'
         """
+        # Copied rather than edited in place. Cheaper than the serialise-and-
+        # reparse this method replaced (measured ~14ms vs ~24ms on a 76 KB
+        # body), and negligible beside the network fetch that produced the
+        # markup - so purity here costs nothing that matters.
+        scope = copy.copy(scope)
+
         # Dropped here rather than in extract(), because the PMC paths enter
         # through this method and a JSON-LD blob or stylesheet landing in
         # cached article text would corrupt every snippet checked against it.

--- a/src/linkml_reference_validator/etl/extract/html.py
+++ b/src/linkml_reference_validator/etl/extract/html.py
@@ -1,7 +1,7 @@
 """HTML content extractor."""
 
 import logging
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from bs4 import BeautifulSoup  # type: ignore
 
@@ -52,14 +52,38 @@ class HTMLExtractor(Extractor):
         for tag in soup(["script", "style"]):
             tag.decompose()
 
+        region = soup.find("article") or soup.find("main")
+        return self.extract_scope(region if region is not None else soup)
+
+    def extract_scope(self, scope: Any) -> Optional[str]:
+        """Extract text from an already-selected region of parsed markup.
+
+        Callers that have chosen their own region - a PMC ``div.article-body``,
+        say - pass the tag straight in. Serialising it back to markup for
+        ``extract`` would parse the whole body a second time, and would re-run
+        the ``<article>``/``<main>`` selection *inside* a region the caller had
+        already settled, silently narrowing to a nested one.
+
+        Args:
+            scope: A BeautifulSoup tag or soup to take the text of
+
+        Returns:
+            The region's text, or None if it holds none
+
+        Examples:
+            >>> from bs4 import BeautifulSoup
+            >>> region = BeautifulSoup(
+            ...     "<div><p>near (<i>GUSB</i>, <i>GRN</i>) here</p></div>",
+            ...     "html.parser",
+            ... ).find("div")
+            >>> HTMLExtractor().extract_scope(region)
+            'near (GUSB, GRN) here'
+        """
         # Before either branch, so both agree: <br> carries no text of its own,
         # so bare get_text() would weld the lines it separates into
         # "Line oneLine two" - the same welding this extractor exists to avoid.
-        for line_break in soup.find_all("br"):
+        for line_break in scope.find_all("br"):
             line_break.replace_with("\n")
-
-        region = soup.find("article") or soup.find("main")
-        scope = region if region is not None else soup
 
         paragraphs = scope.find_all("p")
         if paragraphs:

--- a/src/linkml_reference_validator/etl/extract/html.py
+++ b/src/linkml_reference_validator/etl/extract/html.py
@@ -50,6 +50,12 @@ class HTMLExtractor(Extractor):
         for tag in soup(["script", "style"]):
             tag.decompose()
 
+        # Before either branch, so both agree: <br> carries no text of its own,
+        # so bare get_text() would weld the lines it separates into
+        # "Line oneLine two" - the same welding this extractor exists to avoid.
+        for line_break in soup.find_all("br"):
+            line_break.replace_with("\n")
+
         region = soup.find("article") or soup.find("main")
         scope = region if region is not None else soup
 
@@ -71,8 +77,6 @@ class HTMLExtractor(Extractor):
         # "(<i>GUSB</i>, <i>GRN</i>)" would come out as "(\nGUSB\n,\nGRN\n)".
         # Marking block boundaries first means get_text() can then run bare,
         # keeping the source's own spacing inside each block.
-        for line_break in scope.find_all("br"):
-            line_break.replace_with("\n")
         for block in scope.find_all(BLOCK_LEVEL_TAGS):
             block.insert_after("\n")
 

--- a/src/linkml_reference_validator/etl/extract/html.py
+++ b/src/linkml_reference_validator/etl/extract/html.py
@@ -1,7 +1,7 @@
 """HTML content extractor."""
 
 import logging
-from typing import Optional
+from typing import Optional, Union
 
 from bs4 import BeautifulSoup  # type: ignore
 
@@ -44,7 +44,9 @@ class HTMLExtractor(Extractor):
     def formats(cls) -> list[str]:
         return ["html"]
 
-    def extract(self, data: bytes, *, content_type: Optional[str] = None) -> Optional[str]:
+    def extract(
+        self, data: Union[bytes, str], *, content_type: Optional[str] = None
+    ) -> Optional[str]:
         soup = BeautifulSoup(data, "html.parser")
 
         for tag in soup(["script", "style"]):

--- a/src/linkml_reference_validator/etl/extract/html.py
+++ b/src/linkml_reference_validator/etl/extract/html.py
@@ -9,6 +9,17 @@ from linkml_reference_validator.etl.extract.base import Extractor, ExtractorRegi
 
 logger = logging.getLogger(__name__)
 
+#: Tags whose boundaries are real text breaks. Used by the whole-document
+#: fallback to separate blocks without touching inline markup, so that a
+#: separator never lands between a gene symbol and its surrounding
+#: punctuation.
+BLOCK_LEVEL_TAGS = (
+    "address", "article", "aside", "blockquote", "div", "dd", "dl", "dt",
+    "figcaption", "figure", "footer", "h1", "h2", "h3", "h4", "h5", "h6",
+    "header", "hr", "li", "main", "nav", "ol", "p", "pre", "section",
+    "table", "td", "th", "tr", "ul",
+)
+
 
 @ExtractorRegistry.register
 class HTMLExtractor(Extractor):
@@ -55,5 +66,15 @@ class HTMLExtractor(Extractor):
             if text:
                 return text
 
-        text = scope.get_text(separator="\n", strip=True)
-        return text if text.strip() else None
+        # Same hazard as the paragraph branch, one level down: a blanket
+        # separator lands between *every* pair of markup-delimited runs, so
+        # "(<i>GUSB</i>, <i>GRN</i>)" would come out as "(\nGUSB\n,\nGRN\n)".
+        # Marking block boundaries first means get_text() can then run bare,
+        # keeping the source's own spacing inside each block.
+        for line_break in scope.find_all("br"):
+            line_break.replace_with("\n")
+        for block in scope.find_all(BLOCK_LEVEL_TAGS):
+            block.insert_after("\n")
+
+        text = scope.get_text().strip()
+        return text if text else None

--- a/src/linkml_reference_validator/etl/extract/html.py
+++ b/src/linkml_reference_validator/etl/extract/html.py
@@ -1,4 +1,9 @@
-"""HTML content extractor."""
+"""HTML content extractor.
+
+Changing what this yields for the same input may make already-cached text wrong
+rather than merely older; see :mod:`linkml_reference_validator.etl.extract` for
+when to bump ``EXTRACTOR_CACHE_VERSION``.
+"""
 
 import copy
 import logging

--- a/src/linkml_reference_validator/etl/extract/pdf.py
+++ b/src/linkml_reference_validator/etl/extract/pdf.py
@@ -6,7 +6,7 @@ backends (docling, grobid) can be swapped in later without touching callers.
 
 import io
 import logging
-from typing import Optional, Protocol
+from typing import Optional, Protocol, Union
 
 from linkml_reference_validator.etl.extract.base import Extractor, ExtractorRegistry
 
@@ -62,6 +62,13 @@ class PDFExtractor(Extractor):
     def formats(cls) -> list[str]:
         return ["pdf"]
 
-    def extract(self, data: bytes, *, content_type: Optional[str] = None) -> Optional[str]:
+    def extract(
+        self, data: Union[bytes, str], *, content_type: Optional[str] = None
+    ) -> Optional[str]:
+        # The base accepts str for text formats, but a PDF is binary: decoded
+        # text cannot be reparsed as one, so say so rather than failing deep
+        # inside the backend.
+        if isinstance(data, str):
+            raise TypeError("PDF extraction requires bytes, not decoded text")
         text = self._backend.extract_text(data)
         return text if text and text.strip() else None

--- a/src/linkml_reference_validator/etl/extract/xml.py
+++ b/src/linkml_reference_validator/etl/extract/xml.py
@@ -1,7 +1,7 @@
 """JATS/PMC XML content extractor."""
 
 import logging
-from typing import Optional
+from typing import Optional, Union
 
 from bs4 import BeautifulSoup  # type: ignore
 
@@ -86,10 +86,13 @@ class XMLExtractor(Extractor):
     def formats(cls) -> list[str]:
         return ["xml"]
 
-    def extract(self, data: bytes, *, content_type: Optional[str] = None) -> Optional[str]:
-        # Handed to BeautifulSoup as bytes rather than decoded here: a manual
-        # decode assumes UTF-8 and raises on any article whose XML declares
-        # another encoding, whereas the parser honours the declaration.
+    def extract(
+        self, data: Union[bytes, str], *, content_type: Optional[str] = None
+    ) -> Optional[str]:
+        # Passed through untouched, bytes or str. Decoding bytes here would
+        # assume UTF-8 and raise on any article declaring another encoding;
+        # re-encoding str here would leave that declaration contradicting the
+        # bytes. The parser gets both cases right on its own.
         soup = BeautifulSoup(data, "xml")
         body = soup.find("body")
         if not body:

--- a/src/linkml_reference_validator/etl/extract/xml.py
+++ b/src/linkml_reference_validator/etl/extract/xml.py
@@ -9,18 +9,68 @@ from linkml_reference_validator.etl.extract.base import Extractor, ExtractorRegi
 
 logger = logging.getLogger(__name__)
 
+#: Phrases appearing in the placeholder documents PMC serves in place of an
+#: article whose full text it cannot supply.
+STUB_NOTICE_PHRASES = (
+    "does not allow downloading",
+    "cannot be obtained",
+    "not available from pmc",
+    "full text is restricted",
+    "access to the full text is restricted",
+)
+
+#: Longest a placeholder notice can plausibly be. Stub phrases are only
+#: honoured below this length: a real article runs to tens of thousands of
+#: characters and may legitimately use the same words - Morris 2019 restricts
+#: an analysis "to up to 13,977,204 high quality HRC imputed variants", and a
+#: bare substring scan discarded the entire 155 KB paper for saying so.
+MAX_STUB_NOTICE_CHARS = 1000
+
+
+def is_stub_notice(text: str) -> bool:
+    """Report whether extracted text is a PMC placeholder rather than an article.
+
+    Both conditions must hold: the text carries a placeholder phrase *and* it is
+    short enough to be one. Length is what makes the phrases safe to match, so
+    prose in a real article body can never be mistaken for a stub.
+
+    Args:
+        text: Text extracted from the article body
+
+    Returns:
+        True if the text is a placeholder notice rather than article content
+
+    Examples:
+        >>> is_stub_notice("The full text cannot be obtained from PMC.")
+        True
+        >>> is_stub_notice("Analysis was restricted to imputed variants.")
+        False
+        >>> long_article = "Analysis cannot be obtained here. " + "body text. " * 200
+        >>> is_stub_notice(long_article)
+        False
+    """
+    if len(text) > MAX_STUB_NOTICE_CHARS:
+        return False
+
+    lowered = text.lower()
+    return any(phrase in lowered for phrase in STUB_NOTICE_PHRASES)
+
 
 @ExtractorRegistry.register
 class XMLExtractor(Extractor):
     """Extract body text from JATS/PMC article XML.
 
     Returns the concatenated text of paragraphs within the article ``<body>``.
-    Returns None when there is no body content (e.g. restricted articles).
+    Returns None when there is no body content, and when the body holds one of
+    PMC's placeholder notices instead of the article itself.
 
     Examples:
         >>> xml = b"<article><body><p>Hello body.</p></body></article>"
         >>> XMLExtractor().extract(xml)
         'Hello body.'
+        >>> stub = b"<article><body><p>Text cannot be obtained from PMC.</p></body></article>"
+        >>> XMLExtractor().extract(stub) is None
+        True
     """
 
     @classmethod
@@ -29,9 +79,6 @@ class XMLExtractor(Extractor):
 
     def extract(self, data: bytes, *, content_type: Optional[str] = None) -> Optional[str]:
         text_data = data.decode("utf-8") if isinstance(data, bytes) else data
-
-        if "cannot be obtained" in text_data.lower() or "restricted" in text_data.lower():
-            return None
 
         soup = BeautifulSoup(text_data, "xml")
         body = soup.find("body")
@@ -43,4 +90,14 @@ class XMLExtractor(Extractor):
             return None
 
         text = "\n\n".join(p.get_text() for p in paragraphs if p.get_text().strip())
-        return text if text.strip() else None
+        if not text.strip():
+            return None
+
+        # Judged on the extracted body, not the raw markup: a citation title or
+        # a methods sentence elsewhere in the document says nothing about
+        # whether PMC served us the article.
+        if is_stub_notice(text):
+            logger.debug("Discarding PMC placeholder notice instead of article text")
+            return None
+
+        return text

--- a/src/linkml_reference_validator/etl/extract/xml.py
+++ b/src/linkml_reference_validator/etl/extract/xml.py
@@ -87,9 +87,10 @@ class XMLExtractor(Extractor):
         return ["xml"]
 
     def extract(self, data: bytes, *, content_type: Optional[str] = None) -> Optional[str]:
-        text_data = data.decode("utf-8") if isinstance(data, bytes) else data
-
-        soup = BeautifulSoup(text_data, "xml")
+        # Handed to BeautifulSoup as bytes rather than decoded here: a manual
+        # decode assumes UTF-8 and raises on any article whose XML declares
+        # another encoding, whereas the parser honours the declaration.
+        soup = BeautifulSoup(data, "xml")
         body = soup.find("body")
         if not body:
             return None

--- a/src/linkml_reference_validator/etl/extract/xml.py
+++ b/src/linkml_reference_validator/etl/extract/xml.py
@@ -1,4 +1,9 @@
-"""JATS/PMC XML content extractor."""
+"""JATS/PMC XML content extractor.
+
+Changing what this yields for the same input may make already-cached text wrong
+rather than merely older; see :mod:`linkml_reference_validator.etl.extract` for
+when to bump ``EXTRACTOR_CACHE_VERSION``.
+"""
 
 import logging
 from typing import Optional, Union

--- a/src/linkml_reference_validator/etl/extract/xml.py
+++ b/src/linkml_reference_validator/etl/extract/xml.py
@@ -10,13 +10,16 @@ from linkml_reference_validator.etl.extract.base import Extractor, ExtractorRegi
 logger = logging.getLogger(__name__)
 
 #: Phrases appearing in the placeholder documents PMC serves in place of an
-#: article whose full text it cannot supply.
+#: article whose full text it cannot supply. Deliberately broad, because the
+#: length gate below - not the wording - is what keeps matching safe. PMC
+#: phrases these notices several ways ("access to this article is
+#: restricted", "full text is restricted", ...), and an exhaustive list would
+#: trade the old false positives for false negatives.
 STUB_NOTICE_PHRASES = (
+    "restricted",
     "does not allow downloading",
     "cannot be obtained",
     "not available from pmc",
-    "full text is restricted",
-    "access to the full text is restricted",
 )
 
 #: Longest a placeholder notice can plausibly be. Stub phrases are only
@@ -43,10 +46,16 @@ def is_stub_notice(text: str) -> bool:
     Examples:
         >>> is_stub_notice("The full text cannot be obtained from PMC.")
         True
-        >>> is_stub_notice("Analysis was restricted to imputed variants.")
+        >>> is_stub_notice("Access to this article is restricted.")
+        True
+        >>> is_stub_notice("A brief note about the assay.")
         False
-        >>> long_article = "Analysis cannot be obtained here. " + "body text. " * 200
-        >>> is_stub_notice(long_article)
+
+        The same words inside a real article body are not a stub, however
+        many ways PMC might have phrased its notice:
+
+        >>> article = "Analysis was restricted to imputed variants. " + "Body. " * 200
+        >>> is_stub_notice(article)
         False
     """
     if len(text) > MAX_STUB_NOTICE_CHARS:
@@ -97,7 +106,13 @@ class XMLExtractor(Extractor):
         # a methods sentence elsewhere in the document says nothing about
         # whether PMC served us the article.
         if is_stub_notice(text):
-            logger.debug("Discarding PMC placeholder notice instead of article text")
+            # Logged at info, not debug: silently discarding an article is what
+            # made the original over-matching bug so hard to spot.
+            logger.info(
+                "Discarding a %d-character PMC placeholder notice; no full text "
+                "was served for this article",
+                len(text),
+            )
             return None
 
         return text

--- a/src/linkml_reference_validator/etl/extract/xml.py
+++ b/src/linkml_reference_validator/etl/extract/xml.py
@@ -29,6 +29,19 @@ STUB_NOTICE_PHRASES = (
 #: bare substring scan discarded the entire 155 KB paper for saying so.
 MAX_STUB_NOTICE_CHARS = 1000
 
+#: Shortest text any source will accept as full text rather than a stub.
+#: Kept here beside MAX_STUB_NOTICE_CHARS, and imported by every gate, so the
+#: two can be reasoned about together in one place.
+#:
+#: They move together, but their safe directions are opposite. Raising the
+#: notice length to catch a longer wording is safe. LOWERING it - the tempting
+#: fix for a short erratum discarded for saying "restricted" - would drag this
+#: floor down too and start admitting stubs in the band it just vacated. Only
+#: the XML path runs is_stub_notice, so on the HTML paths this floor is the
+#: sole defence. Lower the notice length only by pinning this to a literal
+#: first.
+MIN_FULLTEXT_CHARS = MAX_STUB_NOTICE_CHARS
+
 
 def is_stub_notice(text: str) -> bool:
     """Report whether extracted text is a PMC placeholder rather than an article.

--- a/src/linkml_reference_validator/etl/fulltext/pmc.py
+++ b/src/linkml_reference_validator/etl/fulltext/pmc.py
@@ -33,6 +33,13 @@ logger = logging.getLogger(__name__)
 # on the HTML paths this length gate is the *only* thing standing between a
 # placeholder page and the cache - tying the two together keeps that true if
 # the notice length is ever raised.
+#
+# The two move together, but their safe directions are opposite. Raising
+# MAX_STUB_NOTICE_CHARS to catch a longer notice wording is safe, and is the
+# case this coupling exists for. LOWERING it - the tempting fix for a short
+# erratum being discarded for saying "restricted" - drags this gate down with
+# it and starts admitting stubs in the band it just vacated. Lower the notice
+# length only with a floor kept here.
 _MIN_PMC_FULLTEXT_CHARS = MAX_STUB_NOTICE_CHARS
 
 

--- a/src/linkml_reference_validator/etl/fulltext/pmc.py
+++ b/src/linkml_reference_validator/etl/fulltext/pmc.py
@@ -6,7 +6,7 @@ fetched from the PMC XML API (with an HTML fallback) and extracted via XMLExtrac
 
 import logging
 import time
-from typing import Optional
+from typing import Optional, Union
 
 from Bio import Entrez  # type: ignore
 from bs4 import BeautifulSoup  # type: ignore
@@ -21,6 +21,7 @@ from linkml_reference_validator.etl.fulltext.base import (
     FullTextProvider,
     FullTextProviderRegistry,
 )
+from linkml_reference_validator.etl.extract.html import HTMLExtractor
 from linkml_reference_validator.etl.extract.xml import XMLExtractor
 
 logger = logging.getLogger(__name__)
@@ -97,14 +98,20 @@ class PMCFullTextProvider(FullTextProvider):
                         return str(first_link["Id"])
         return None
 
-    def _fetch_pmc_xml_bytes(self, pmcid: str, config: ReferenceValidationConfig) -> Optional[bytes]:
-        """Fetch raw PMC XML bytes for a PMC ID."""
+    def _fetch_pmc_xml_bytes(
+        self, pmcid: str, config: ReferenceValidationConfig
+    ) -> Optional[Union[bytes, str]]:
+        """Fetch raw PMC XML for a PMC ID, exactly as Entrez returned it.
+
+        Returned unconverted: Entrez hands back str, and encoding it to UTF-8
+        would leave any ISO-8859-1 declaration in front of UTF-8 bytes for the
+        parser to believe, turning "François" into "FranÃ§ois". XMLExtractor
+        accepts either form and gets both right.
+        """
         time.sleep(config.rate_limit_delay)
         handle = Entrez.efetch(db="pmc", id=pmcid, rettype="xml", retmode="xml")
         xml_content = handle.read()
         handle.close()
-        if isinstance(xml_content, str):
-            xml_content = xml_content.encode("utf-8")
         return xml_content
 
     def _fetch_pmc_html(self, pmcid: str, config: ReferenceValidationConfig) -> Optional[str]:
@@ -118,7 +125,9 @@ class PMCFullTextProvider(FullTextProvider):
         soup = BeautifulSoup(response.content, "html.parser")
         article_body = soup.find("div", class_="article-body") or soup.find("div", class_="tsec")
         if article_body:
-            paragraphs = article_body.find_all("p")
-            if paragraphs:
-                return "\n\n".join(p.get_text() for p in paragraphs)
+            # The region is selected here, but the text comes out of the shared
+            # extractor rather than a private copy of the paragraph walk, so
+            # this path gets its <br> handling and block-boundary fallback
+            # instead of quietly drifting from it.
+            return HTMLExtractor().extract(str(article_body), content_type="text/html")
         return None

--- a/src/linkml_reference_validator/etl/fulltext/pmc.py
+++ b/src/linkml_reference_validator/etl/fulltext/pmc.py
@@ -22,7 +22,8 @@ from linkml_reference_validator.etl.fulltext.base import (
     FullTextProviderRegistry,
 )
 from linkml_reference_validator.etl.extract.html import HTMLExtractor
-from linkml_reference_validator.etl.extract.xml import MIN_FULLTEXT_CHARS, XMLExtractor
+from linkml_reference_validator.etl.extract import MIN_FULLTEXT_CHARS
+from linkml_reference_validator.etl.extract.xml import XMLExtractor
 
 logger = logging.getLogger(__name__)
 

--- a/src/linkml_reference_validator/etl/fulltext/pmc.py
+++ b/src/linkml_reference_validator/etl/fulltext/pmc.py
@@ -22,14 +22,18 @@ from linkml_reference_validator.etl.fulltext.base import (
     FullTextProviderRegistry,
 )
 from linkml_reference_validator.etl.extract.html import HTMLExtractor
-from linkml_reference_validator.etl.extract.xml import XMLExtractor
+from linkml_reference_validator.etl.extract.xml import MAX_STUB_NOTICE_CHARS, XMLExtractor
 
 logger = logging.getLogger(__name__)
 
-# 2x the global MIN_FULL_TEXT_CHARS floor (reference_fetcher.py): a PMC XML/HTML
-# response under ~1k chars is almost always a stub (title + abstract, or a stripped
-# landing page) rather than the article body, so we reject it and fall through.
-_MIN_PMC_FULLTEXT_CHARS = 1000
+# Derived from the stub-notice length rather than repeating its value: a PMC
+# XML/HTML response no longer than a placeholder notice is almost always one
+# (title + abstract, or a stripped landing page) rather than the article body,
+# so we reject it and fall through. Only the XML path runs is_stub_notice, so
+# on the HTML paths this length gate is the *only* thing standing between a
+# placeholder page and the cache - tying the two together keeps that true if
+# the notice length is ever raised.
+_MIN_PMC_FULLTEXT_CHARS = MAX_STUB_NOTICE_CHARS
 
 
 @FullTextProviderRegistry.register
@@ -57,9 +61,9 @@ class PMCFullTextProvider(FullTextProvider):
 
         Entrez.email = config.email  # type: ignore
 
-        xml_bytes = self._fetch_pmc_xml_bytes(pmcid, config)
-        if xml_bytes:
-            text = XMLExtractor().extract(xml_bytes, content_type="application/xml")
+        xml_source = self._fetch_pmc_xml_source(pmcid, config)
+        if xml_source:
+            text = XMLExtractor().extract(xml_source, content_type="application/xml")
             if text and len(text) > _MIN_PMC_FULLTEXT_CHARS:
                 return FullTextLocation(
                     text=text, format_hint="xml", oa_status="green", provider="pmc"
@@ -98,7 +102,7 @@ class PMCFullTextProvider(FullTextProvider):
                         return str(first_link["Id"])
         return None
 
-    def _fetch_pmc_xml_bytes(
+    def _fetch_pmc_xml_source(
         self, pmcid: str, config: ReferenceValidationConfig
     ) -> Optional[Union[bytes, str]]:
         """Fetch raw PMC XML for a PMC ID, exactly as Entrez returned it.
@@ -129,5 +133,5 @@ class PMCFullTextProvider(FullTextProvider):
             # extractor rather than a private copy of the paragraph walk, so
             # this path gets its <br> handling and block-boundary fallback
             # instead of quietly drifting from it.
-            return HTMLExtractor().extract(str(article_body), content_type="text/html")
+            return HTMLExtractor().extract_scope(article_body)
         return None

--- a/src/linkml_reference_validator/etl/fulltext/pmc.py
+++ b/src/linkml_reference_validator/etl/fulltext/pmc.py
@@ -22,25 +22,9 @@ from linkml_reference_validator.etl.fulltext.base import (
     FullTextProviderRegistry,
 )
 from linkml_reference_validator.etl.extract.html import HTMLExtractor
-from linkml_reference_validator.etl.extract.xml import MAX_STUB_NOTICE_CHARS, XMLExtractor
+from linkml_reference_validator.etl.extract.xml import MIN_FULLTEXT_CHARS, XMLExtractor
 
 logger = logging.getLogger(__name__)
-
-# Derived from the stub-notice length rather than repeating its value: a PMC
-# XML/HTML response no longer than a placeholder notice is almost always one
-# (title + abstract, or a stripped landing page) rather than the article body,
-# so we reject it and fall through. Only the XML path runs is_stub_notice, so
-# on the HTML paths this length gate is the *only* thing standing between a
-# placeholder page and the cache - tying the two together keeps that true if
-# the notice length is ever raised.
-#
-# The two move together, but their safe directions are opposite. Raising
-# MAX_STUB_NOTICE_CHARS to catch a longer notice wording is safe, and is the
-# case this coupling exists for. LOWERING it - the tempting fix for a short
-# erratum being discarded for saying "restricted" - drags this gate down with
-# it and starts admitting stubs in the band it just vacated. Lower the notice
-# length only with a floor kept here.
-_MIN_PMC_FULLTEXT_CHARS = MAX_STUB_NOTICE_CHARS
 
 
 @FullTextProviderRegistry.register
@@ -71,13 +55,16 @@ class PMCFullTextProvider(FullTextProvider):
         xml_source = self._fetch_pmc_xml_source(pmcid, config)
         if xml_source:
             text = XMLExtractor().extract(xml_source, content_type="application/xml")
-            if text and len(text) > _MIN_PMC_FULLTEXT_CHARS:
+            # The shared floor, not a local threshold - see MIN_FULLTEXT_CHARS
+            # in extract/xml.py, which carries the reasoning. On the HTML
+            # fallback below it is the only stub defence there is.
+            if text and len(text) > MIN_FULLTEXT_CHARS:
                 return FullTextLocation(
                     text=text, format_hint="xml", oa_status="green", provider="pmc"
                 )
 
         html_text = self._fetch_pmc_html(pmcid, config)
-        if html_text and len(html_text) > _MIN_PMC_FULLTEXT_CHARS:
+        if html_text and len(html_text) > MIN_FULLTEXT_CHARS:
             return FullTextLocation(
                 text=html_text, format_hint="html", oa_status="green", provider="pmc"
             )

--- a/src/linkml_reference_validator/etl/reference_fetcher.py
+++ b/src/linkml_reference_validator/etl/reference_fetcher.py
@@ -56,6 +56,14 @@ MIN_FULL_TEXT_CHARS = 500
 #: nothing in the output to explain why.
 EXTRACTOR_CACHE_VERSION = 1
 
+#: A cache file's frontmatter delimiter: a line that is exactly ``---``.
+#: Splitting on the bare string instead lets any *value* containing ``---`` - a
+#: URL reference_id, a title - truncate the block, which loses every field after
+#: it and hides the version stamp. An entry whose stamp is hidden reads as
+#: unstamped, so it is re-fetched, rewritten with the same id, and read as
+#: unstamped again: a re-fetch on every run, forever.
+_FRONTMATTER_DELIMITER = re.compile(r"^---[ \t]*$", re.MULTILINE)
+
 _FORMAT_TO_CONTENT_TYPE = {
     "pdf": "full_text_pdf",
     "html": "full_text_html",
@@ -153,7 +161,7 @@ class ReferenceFetcher:
         source_class = ReferenceSourceRegistry.get_source(normalized_reference_id)
         if not source_class:
             logger.warning(f"No source found for reference type: {normalized_reference_id}")
-            return None
+            return self._stale_fallback(normalized_reference_id, force_refresh)
 
         # Parse identifier and fetch
         _, identifier = self._parse_reference_id(normalized_reference_id)
@@ -163,11 +171,44 @@ class ReferenceFetcher:
         if content and self.config.fetch_full_text and self.needs_full_text(content):
             content = self._enrich_with_full_text(content)
 
-        if content:
-            self._cache[normalized_reference_id] = content
-            self._save_by_access(content)
+        if not content:
+            return self._stale_fallback(normalized_reference_id, force_refresh)
+
+        self._cache[normalized_reference_id] = content
+        self._save_by_access(content)
 
         return content
+
+    def _stale_fallback(
+        self, normalized_reference_id: str, force_refresh: bool
+    ) -> Optional[ReferenceContent]:
+        """Serve an out-of-date cache entry when the source yielded nothing.
+
+        A stale entry is treated as absent on the happy path so the current
+        extractors rewrite it. That is only safe while a replacement can actually
+        be fetched: offline, during a provider outage, or for a record since
+        withdrawn, "this text is out of date" must not become "this reference does
+        not exist". The older copy is worse than a fresh fetch and much better than
+        reporting every cached reference as not found.
+
+        The entry is deliberately not re-saved, so it stays stale and the next run
+        that can reach the source still refreshes it. ``force_refresh`` opts out
+        entirely: an explicit refresh that failed should report failure.
+        """
+        if force_refresh:
+            return None
+
+        stale = self._load_from_disk(normalized_reference_id, allow_stale=True)
+        if stale is None:
+            return None
+
+        logger.warning(
+            "Could not re-fetch %s; using the cache entry written by an older "
+            "extractor. Its text may still contain the errors this version fixes.",
+            normalized_reference_id,
+        )
+        self._cache[normalized_reference_id] = stale
+        return stale
 
     def needs_full_text(self, content: ReferenceContent) -> bool:
         """Return True if the content lacks full text and the chain should run.
@@ -711,7 +752,9 @@ class ReferenceFetcher:
             cache_path.chmod(0o600)
         logger.info(f"Cached {reference.reference_id} to {cache_path}")
 
-    def _load_from_disk(self, reference_id: str) -> Optional[ReferenceContent]:
+    def _load_from_disk(
+        self, reference_id: str, allow_stale: bool = False
+    ) -> Optional[ReferenceContent]:
         """Load reference content from the public validation cache.
 
         Supports both new markdown format with YAML frontmatter and legacy text format.
@@ -720,39 +763,43 @@ class ReferenceFetcher:
 
         Args:
             reference_id: Reference identifier
+            allow_stale: Return entries written by an older extractor instead of
+                treating them as absent. Used only by :meth:`_stale_fallback`,
+                once a fetch has already failed to produce a replacement.
 
         Returns:
             ReferenceContent if cached, None otherwise
         """
         cache_path = self.get_cache_path(reference_id)
+        is_legacy = False
 
         if not cache_path.exists():
             legacy_path = cache_path.with_suffix(".txt")
-            if legacy_path.exists():
-                # Deliberately exempt from the staleness check below. The
-                # pre-Markdown format is a read-only compatibility path that
-                # nothing has written for a long time, so such entries are as
-                # likely to be hand-maintained as tool-written - and they are
-                # not what the extractor bugs produced, since those wrote
-                # Markdown. Re-fetching them would discard someone's data to
-                # fix a problem they do not have.
-                cache_path = legacy_path
-            else:
+            if not legacy_path.exists():
                 return None
+            cache_path = legacy_path
+            is_legacy = True
 
         content_text = cache_path.read_text(encoding="utf-8")
 
-        if content_text.startswith("---"):
-            if self._is_stale_cache_entry(content_text):
-                logger.info(
-                    "Ignoring cache entry for %s written by an older extractor; "
-                    "it will be re-fetched and rewritten",
-                    reference_id,
-                )
-                return None
-            return self._load_markdown_format(content_text, reference_id)
-        else:
+        # The pre-Markdown format has no frontmatter to stamp, and is deliberately
+        # exempt from the staleness check rather than perpetually stale: it is a
+        # read-only compatibility path that nothing has written for a long time,
+        # so such entries are as likely to be hand-maintained as tool-written -
+        # and they are not what the extractor bugs produced, since those wrote
+        # Markdown. Re-fetching them would discard someone's data to fix a
+        # problem they do not have.
+        if is_legacy or not content_text.startswith("---"):
             return self._load_legacy_format(content_text, reference_id)
+
+        if not allow_stale and self._is_stale_cache_entry(content_text):
+            logger.info(
+                "Ignoring cache entry for %s written by an older extractor; "
+                "it will be re-fetched and rewritten",
+                reference_id,
+            )
+            return None
+        return self._load_markdown_format(content_text, reference_id)
 
     @staticmethod
     def _as_optional_list(value: Any) -> Optional[list]:
@@ -774,7 +821,31 @@ class ReferenceFetcher:
         return value if isinstance(value, list) else [value]
 
     @staticmethod
-    def _is_stale_cache_entry(content_text: str) -> bool:
+    def _split_frontmatter(content_text: str) -> Optional[tuple[str, str]]:
+        """Split cache-file text into ``(frontmatter, body)``.
+
+        Args:
+            content_text: The cache file's contents
+
+        Returns:
+            The frontmatter and body, or None if the text is not delimited
+
+        Examples:
+            >>> ReferenceFetcher._split_frontmatter("---\\nyear: '2024'\\n---\\nBody.")
+            ("\\nyear: '2024'\\n", '\\nBody.')
+            >>> ReferenceFetcher._split_frontmatter("Body with no frontmatter.") is None
+            True
+            >>> # A value containing --- is not a delimiter; only a line that is
+            >>> ReferenceFetcher._split_frontmatter("---\\ntitle: a---b\\n---\\nBody.")
+            ('\\ntitle: a---b\\n', '\\nBody.')
+        """
+        parts = _FRONTMATTER_DELIMITER.split(content_text, maxsplit=2)
+        if len(parts) < 3:
+            return None
+        return parts[1], parts[2]
+
+    @classmethod
+    def _is_stale_cache_entry(cls, content_text: str) -> bool:
         """Report whether cached text came from an extractor older than this one.
 
         Deliberately not applied by :meth:`iter_cached_references`: export and
@@ -797,11 +868,11 @@ class ReferenceFetcher:
             >>> ReferenceFetcher._is_stale_cache_entry(current)
             False
         """
-        parts = content_text.split("---", 2)
-        if len(parts) < 3:
+        split = cls._split_frontmatter(content_text)
+        if split is None:
             return True
 
-        match = re.search(r"^extractor_version:\s*(\d+)\s*$", parts[1], re.MULTILINE)
+        match = re.search(r"^extractor_version:\s*(\d+)\s*$", split[0], re.MULTILINE)
         if not match:
             return True
 
@@ -821,14 +892,14 @@ class ReferenceFetcher:
         Returns:
             ReferenceContent if successful, None otherwise
         """
-        parts = content_text.split("---", 2)
-        if len(parts) < 3:
+        split = self._split_frontmatter(content_text)
+        if split is None:
             logger.warning(f"Invalid markdown format for {reference_id}")
             return None
 
         yaml_parser = YAML(typ="safe")
-        frontmatter = yaml_parser.load(parts[1])
-        body = parts[2].strip()
+        frontmatter = yaml_parser.load(split[0])
+        body = split[1].strip()
 
         content = self._extract_content_from_markdown(body)
 

--- a/src/linkml_reference_validator/etl/reference_fetcher.py
+++ b/src/linkml_reference_validator/etl/reference_fetcher.py
@@ -43,6 +43,19 @@ NEEDS_FULL_TEXT_TYPES = {
 # since a PMC XML/HTML hit under ~1k chars is almost always a stub, not the body).
 MIN_FULL_TEXT_CHARS = 500
 
+#: Bumped whenever an extraction change means previously cached text is wrong
+#: rather than merely older. Entries stamped below this are re-fetched on the
+#: next validation that needs them, one reference at a time.
+#:
+#: Version 1: the stub-detection and markup-welding fixes. Before them, an
+#: article whose methods said "restricted" was discarded and an 8.7 KB
+#: placeholder cached as its full text, and inline markup was welded to its
+#: neighbours - "(GUSB, GRN, and NEU1)" stored as "(GUSB,GRN, andNEU1)".
+#: Correcting the extractors does not rewrite what they already wrote, so
+#: without this stamp every existing cache keeps failing correct snippets with
+#: nothing in the output to explain why.
+EXTRACTOR_CACHE_VERSION = 1
+
 _FORMAT_TO_CONTENT_TYPE = {
     "pdf": "full_text_pdf",
     "html": "full_text_html",
@@ -591,6 +604,7 @@ class ReferenceFetcher:
         lines = []
         lines.append("---")
         lines.append(f"reference_id: {reference.reference_id}")
+        lines.append(f"extractor_version: {EXTRACTOR_CACHE_VERSION}")
         if reference.title:
             lines.append(f"title: {self._quote_yaml_value(reference.title)}")
         if reference.authors:
@@ -715,6 +729,13 @@ class ReferenceFetcher:
         if not cache_path.exists():
             legacy_path = cache_path.with_suffix(".txt")
             if legacy_path.exists():
+                # Deliberately exempt from the staleness check below. The
+                # pre-Markdown format is a read-only compatibility path that
+                # nothing has written for a long time, so such entries are as
+                # likely to be hand-maintained as tool-written - and they are
+                # not what the extractor bugs produced, since those wrote
+                # Markdown. Re-fetching them would discard someone's data to
+                # fix a problem they do not have.
                 cache_path = legacy_path
             else:
                 return None
@@ -722,6 +743,13 @@ class ReferenceFetcher:
         content_text = cache_path.read_text(encoding="utf-8")
 
         if content_text.startswith("---"):
+            if self._is_stale_cache_entry(content_text):
+                logger.info(
+                    "Ignoring cache entry for %s written by an older extractor; "
+                    "it will be re-fetched and rewritten",
+                    reference_id,
+                )
+                return None
             return self._load_markdown_format(content_text, reference_id)
         else:
             return self._load_legacy_format(content_text, reference_id)
@@ -744,6 +772,42 @@ class ReferenceFetcher:
         if not value:
             return None
         return value if isinstance(value, list) else [value]
+
+    @staticmethod
+    def _is_stale_cache_entry(content_text: str) -> bool:
+        """Report whether cached text came from an extractor older than this one.
+
+        Deliberately not applied by :meth:`iter_cached_references`: export and
+        enrichment walk the cache as a record of what was fetched, and dropping
+        older entries there would lose them rather than refresh them. Only the
+        validation read path treats a stale entry as absent, so it is re-fetched
+        and rewritten.
+
+        Args:
+            content_text: The cache file's contents, including frontmatter
+
+        Returns:
+            True if the entry has no version stamp, or one below the current
+
+        Examples:
+            >>> stale = "---\\nreference_id: PMID:1\\n---\\nBody."
+            >>> ReferenceFetcher._is_stale_cache_entry(stale)
+            True
+            >>> current = f"---\\nextractor_version: {EXTRACTOR_CACHE_VERSION}\\n---\\nBody."
+            >>> ReferenceFetcher._is_stale_cache_entry(current)
+            False
+        """
+        parts = content_text.split("---", 2)
+        if len(parts) < 3:
+            return True
+
+        match = re.search(r"^extractor_version:\s*(\d+)\s*$", parts[1], re.MULTILINE)
+        if not match:
+            return True
+
+        # A newer stamp is not stale: an older tool reading a cache written by a
+        # newer one should leave it alone rather than re-fetch it on every run.
+        return int(match.group(1)) < EXTRACTOR_CACHE_VERSION
 
     def _load_markdown_format(
         self, content_text: str, reference_id: str

--- a/src/linkml_reference_validator/etl/sources/pmid.py
+++ b/src/linkml_reference_validator/etl/sources/pmid.py
@@ -354,6 +354,10 @@ class PMIDSource(ReferenceSource):
         if not pmcid:
             return None, "no_pmc"
 
+        # Gated on the stub-notice length for the same reason as the PMC
+        # provider (see _MIN_PMC_FULLTEXT_CHARS there): a response no longer
+        # than a placeholder notice is almost always one, and on the HTML
+        # fallback below this length check is the only stub defence there is.
         full_text = self._fetch_pmc_xml(pmcid, config)
         if full_text and len(full_text) > MAX_STUB_NOTICE_CHARS:
             return full_text, "full_text_xml"

--- a/src/linkml_reference_validator/etl/sources/pmid.py
+++ b/src/linkml_reference_validator/etl/sources/pmid.py
@@ -21,7 +21,7 @@ import requests  # type: ignore
 
 from linkml_reference_validator.models import ReferenceContent, ReferenceValidationConfig
 from linkml_reference_validator.etl.extract.html import HTMLExtractor
-from linkml_reference_validator.etl.extract.xml import MAX_STUB_NOTICE_CHARS, XMLExtractor
+from linkml_reference_validator.etl.extract.xml import MIN_FULLTEXT_CHARS, XMLExtractor
 from linkml_reference_validator.etl.sources.base import ReferenceSource, ReferenceSourceRegistry
 from linkml_reference_validator.etl.sources.utils import (
     extract_extra_fields,
@@ -354,16 +354,15 @@ class PMIDSource(ReferenceSource):
         if not pmcid:
             return None, "no_pmc"
 
-        # Gated on the stub-notice length for the same reason as the PMC
-        # provider (see _MIN_PMC_FULLTEXT_CHARS there): a response no longer
-        # than a placeholder notice is almost always one, and on the HTML
-        # fallback below this length check is the only stub defence there is.
+        # The shared floor, not a local threshold: see MIN_FULLTEXT_CHARS in
+        # extract/xml.py, which carries the reasoning. On the HTML fallback
+        # below it is the only stub defence there is.
         full_text = self._fetch_pmc_xml(pmcid, config)
-        if full_text and len(full_text) > MAX_STUB_NOTICE_CHARS:
+        if full_text and len(full_text) > MIN_FULLTEXT_CHARS:
             return full_text, "full_text_xml"
 
         full_text = self._fetch_pmc_html(pmcid, config)
-        if full_text and len(full_text) > MAX_STUB_NOTICE_CHARS:
+        if full_text and len(full_text) > MIN_FULLTEXT_CHARS:
             return full_text, "full_text_html"
 
         return None, "pmc_restricted"

--- a/src/linkml_reference_validator/etl/sources/pmid.py
+++ b/src/linkml_reference_validator/etl/sources/pmid.py
@@ -422,6 +422,9 @@ class PMIDSource(ReferenceSource):
         xml_content = handle.read()
         handle.close()
 
+        if isinstance(xml_content, str):
+            xml_content = xml_content.encode("utf-8")
+
         # Delegated to the shared extractor so body parsing and PMC
         # placeholder detection cannot drift from the rest of the ETL layer.
         # This module used to carry its own copy, which discarded any article

--- a/src/linkml_reference_validator/etl/sources/pmid.py
+++ b/src/linkml_reference_validator/etl/sources/pmid.py
@@ -257,12 +257,14 @@ class PMIDSource(ReferenceSource):
         xml_content = handle.read()
         handle.close()
 
-        if isinstance(xml_content, bytes):
-            xml_content = xml_content.decode("utf-8")
-
         if not xml_content:
             return None
 
+        # Passed through as returned, for the same reason _fetch_pmc_xml does:
+        # decoding bytes here assumes UTF-8 and raises on a record declaring
+        # another encoding, taking the MeSH terms and publication types with
+        # it. BeautifulSoup honours the declaration for bytes and fixes it up
+        # for str.
         return BeautifulSoup(xml_content, "xml")
 
     def _parse_mesh_terms(self, soup: BeautifulSoup) -> Optional[list[str]]:

--- a/src/linkml_reference_validator/etl/sources/pmid.py
+++ b/src/linkml_reference_validator/etl/sources/pmid.py
@@ -21,7 +21,7 @@ import requests  # type: ignore
 
 from linkml_reference_validator.models import ReferenceContent, ReferenceValidationConfig
 from linkml_reference_validator.etl.extract.html import HTMLExtractor
-from linkml_reference_validator.etl.extract.xml import XMLExtractor
+from linkml_reference_validator.etl.extract.xml import MAX_STUB_NOTICE_CHARS, XMLExtractor
 from linkml_reference_validator.etl.sources.base import ReferenceSource, ReferenceSourceRegistry
 from linkml_reference_validator.etl.sources.utils import (
     extract_extra_fields,
@@ -355,11 +355,11 @@ class PMIDSource(ReferenceSource):
             return None, "no_pmc"
 
         full_text = self._fetch_pmc_xml(pmcid, config)
-        if full_text and len(full_text) > 1000:
+        if full_text and len(full_text) > MAX_STUB_NOTICE_CHARS:
             return full_text, "full_text_xml"
 
         full_text = self._fetch_pmc_html(pmcid, config)
-        if full_text and len(full_text) > 1000:
+        if full_text and len(full_text) > MAX_STUB_NOTICE_CHARS:
             return full_text, "full_text_html"
 
         return None, "pmc_restricted"
@@ -463,6 +463,6 @@ class PMIDSource(ReferenceSource):
             # Region selected here, text extracted by the shared extractor, for
             # the same reason _fetch_pmc_xml delegates: a private paragraph
             # walk drifts from the rest of the ETL layer and misses its fixes.
-            return HTMLExtractor().extract(str(article_body), content_type="text/html")
+            return HTMLExtractor().extract_scope(article_body)
 
         return None

--- a/src/linkml_reference_validator/etl/sources/pmid.py
+++ b/src/linkml_reference_validator/etl/sources/pmid.py
@@ -422,9 +422,11 @@ class PMIDSource(ReferenceSource):
         xml_content = handle.read()
         handle.close()
 
-        if isinstance(xml_content, str):
-            xml_content = xml_content.encode("utf-8")
-
+        # Handed on as-is. Entrez returns str, and re-encoding it to UTF-8
+        # would leave any ISO-8859-1 declaration in place for the parser to
+        # believe, turning "François" into "FranÃ§ois". BeautifulSoup fixes up
+        # the declaration itself when given str.
+        #
         # Delegated to the shared extractor so body parsing and PMC
         # placeholder detection cannot drift from the rest of the ETL layer.
         # This module used to carry its own copy, which discarded any article

--- a/src/linkml_reference_validator/etl/sources/pmid.py
+++ b/src/linkml_reference_validator/etl/sources/pmid.py
@@ -20,6 +20,7 @@ from bs4 import BeautifulSoup  # type: ignore
 import requests  # type: ignore
 
 from linkml_reference_validator.models import ReferenceContent, ReferenceValidationConfig
+from linkml_reference_validator.etl.extract.xml import XMLExtractor
 from linkml_reference_validator.etl.sources.base import ReferenceSource, ReferenceSourceRegistry
 from linkml_reference_validator.etl.sources.utils import (
     extract_extra_fields,
@@ -421,22 +422,11 @@ class PMIDSource(ReferenceSource):
         xml_content = handle.read()
         handle.close()
 
-        if isinstance(xml_content, bytes):
-            xml_content = xml_content.decode("utf-8")
-
-        if "cannot be obtained" in xml_content.lower() or "restricted" in xml_content.lower():
-            return None
-
-        soup = BeautifulSoup(xml_content, "xml")
-        body = soup.find("body")
-
-        if body:
-            paragraphs = body.find_all("p")
-            if paragraphs:
-                text = "\n\n".join(p.get_text() for p in paragraphs)
-                return text
-
-        return None
+        # Delegated to the shared extractor so body parsing and PMC
+        # placeholder detection cannot drift from the rest of the ETL layer.
+        # This module used to carry its own copy, which discarded any article
+        # whose markup mentioned "restricted" anywhere at all.
+        return XMLExtractor().extract(xml_content)
 
     def _fetch_pmc_html(
         self, pmcid: str, config: ReferenceValidationConfig

--- a/src/linkml_reference_validator/etl/sources/pmid.py
+++ b/src/linkml_reference_validator/etl/sources/pmid.py
@@ -21,7 +21,8 @@ import requests  # type: ignore
 
 from linkml_reference_validator.models import ReferenceContent, ReferenceValidationConfig
 from linkml_reference_validator.etl.extract.html import HTMLExtractor
-from linkml_reference_validator.etl.extract.xml import MIN_FULLTEXT_CHARS, XMLExtractor
+from linkml_reference_validator.etl.extract import MIN_FULLTEXT_CHARS
+from linkml_reference_validator.etl.extract.xml import XMLExtractor
 from linkml_reference_validator.etl.sources.base import ReferenceSource, ReferenceSourceRegistry
 from linkml_reference_validator.etl.sources.utils import (
     extract_extra_fields,

--- a/src/linkml_reference_validator/etl/sources/pmid.py
+++ b/src/linkml_reference_validator/etl/sources/pmid.py
@@ -20,6 +20,7 @@ from bs4 import BeautifulSoup  # type: ignore
 import requests  # type: ignore
 
 from linkml_reference_validator.models import ReferenceContent, ReferenceValidationConfig
+from linkml_reference_validator.etl.extract.html import HTMLExtractor
 from linkml_reference_validator.etl.extract.xml import XMLExtractor
 from linkml_reference_validator.etl.sources.base import ReferenceSource, ReferenceSourceRegistry
 from linkml_reference_validator.etl.sources.utils import (
@@ -459,9 +460,9 @@ class PMIDSource(ReferenceSource):
         )
 
         if article_body:
-            paragraphs = article_body.find_all("p")
-            if paragraphs:
-                text = "\n\n".join(p.get_text() for p in paragraphs)
-                return text
+            # Region selected here, text extracted by the shared extractor, for
+            # the same reason _fetch_pmc_xml delegates: a private paragraph
+            # walk drifts from the rest of the ETL layer and misses its fixes.
+            return HTMLExtractor().extract(str(article_body), content_type="text/html")
 
         return None

--- a/src/linkml_reference_validator/models.py
+++ b/src/linkml_reference_validator/models.py
@@ -31,7 +31,8 @@ class RepairActionType(str, Enum):
     FUZZY_CORRECTION = "FUZZY_CORRECTION"  # Replace with closest matching text
     REMOVAL = "REMOVAL"  # Flag for removal (fabricated/not found)
     UNVERIFIABLE = "UNVERIFIABLE"  # No abstract available
-    EMPTY_EXCERPT = "EMPTY_EXCERPT"  # Quotes nothing; no comparison was possible
+    # Quotes nothing, or too little to verify; no comparison was possible
+    INSUFFICIENT_EXCERPT = "INSUFFICIENT_EXCERPT"
 
 
 class RepairConfidence(str, Enum):
@@ -141,8 +142,8 @@ class RepairAction:
             return False
         if self.action_type == RepairActionType.UNVERIFIABLE:
             return False
-        # An empty excerpt has no correct replacement to apply
-        if self.action_type == RepairActionType.EMPTY_EXCERPT:
+        # An insufficient excerpt has no correct replacement to apply
+        if self.action_type == RepairActionType.INSUFFICIENT_EXCERPT:
             return False
         return self.confidence == RepairConfidence.HIGH and self.repaired_text is not None
 
@@ -241,45 +242,44 @@ class RepairReport:
                     count += 1
         return count
 
+    def _count_results_with(self, action_type: RepairActionType) -> int:
+        """Count results carrying at least one action of the given type.
+
+        Args:
+            action_type: The action type to look for
+
+        Returns:
+            Number of results with such an action
+
+        Examples:
+            >>> report = RepairReport()
+            >>> report._count_results_with(RepairActionType.REMOVAL)
+            0
+        """
+        return sum(
+            1
+            for r in self.results
+            if any(a.action_type == action_type for a in r.actions)
+        )
+
     @property
     def removal_count(self) -> int:
         """Number of items flagged for removal."""
-        count = 0
-        for r in self.results:
-            has_removal = any(
-                a.action_type == RepairActionType.REMOVAL for a in r.actions
-            )
-            if has_removal:
-                count += 1
-        return count
+        return self._count_results_with(RepairActionType.REMOVAL)
 
     @property
     def unverifiable_count(self) -> int:
         """Number of items that cannot be verified (no abstract)."""
-        count = 0
-        for r in self.results:
-            has_unverifiable = any(
-                a.action_type == RepairActionType.UNVERIFIABLE for a in r.actions
-            )
-            if has_unverifiable:
-                count += 1
-        return count
+        return self._count_results_with(RepairActionType.UNVERIFIABLE)
 
     @property
-    def empty_excerpt_count(self) -> int:
-        """Number of items whose excerpt quotes nothing.
+    def insufficient_excerpt_count(self) -> int:
+        """Number of items whose excerpt quotes nothing, or too little to verify.
 
         Counted separately from removals: no comparison against the reference
         was made, so these are not a verdict about how well a quote matched.
         """
-        count = 0
-        for r in self.results:
-            has_empty = any(
-                a.action_type == RepairActionType.EMPTY_EXCERPT for a in r.actions
-            )
-            if has_empty:
-                count += 1
-        return count
+        return self._count_results_with(RepairActionType.INSUFFICIENT_EXCERPT)
 
 
 class RepairConfig(BaseModel):

--- a/src/linkml_reference_validator/models.py
+++ b/src/linkml_reference_validator/models.py
@@ -31,6 +31,7 @@ class RepairActionType(str, Enum):
     FUZZY_CORRECTION = "FUZZY_CORRECTION"  # Replace with closest matching text
     REMOVAL = "REMOVAL"  # Flag for removal (fabricated/not found)
     UNVERIFIABLE = "UNVERIFIABLE"  # No abstract available
+    EMPTY_EXCERPT = "EMPTY_EXCERPT"  # Quotes nothing; no comparison was possible
 
 
 class RepairConfidence(str, Enum):
@@ -139,6 +140,9 @@ class RepairAction:
         if self.action_type == RepairActionType.REMOVAL:
             return False
         if self.action_type == RepairActionType.UNVERIFIABLE:
+            return False
+        # An empty excerpt has no correct replacement to apply
+        if self.action_type == RepairActionType.EMPTY_EXCERPT:
             return False
         return self.confidence == RepairConfidence.HIGH and self.repaired_text is not None
 
@@ -258,6 +262,22 @@ class RepairReport:
                 a.action_type == RepairActionType.UNVERIFIABLE for a in r.actions
             )
             if has_unverifiable:
+                count += 1
+        return count
+
+    @property
+    def empty_excerpt_count(self) -> int:
+        """Number of items whose excerpt quotes nothing.
+
+        Counted separately from removals: no comparison against the reference
+        was made, so these are not a verdict about how well a quote matched.
+        """
+        count = 0
+        for r in self.results:
+            has_empty = any(
+                a.action_type == RepairActionType.EMPTY_EXCERPT for a in r.actions
+            )
+            if has_empty:
                 count += 1
         return count
 

--- a/src/linkml_reference_validator/models.py
+++ b/src/linkml_reference_validator/models.py
@@ -357,6 +357,10 @@ class ReferenceValidationConfig(BaseModel):
         ... )
         >>> config.literal_bracket_patterns
         ['\\d', '^[A-Z]$']
+        >>> ReferenceValidationConfig().min_excerpt_length
+        0
+        >>> ReferenceValidationConfig(min_excerpt_length=20).min_excerpt_length
+        20
     """
 
     cache_dir: Path = Field(
@@ -409,6 +413,19 @@ class ReferenceValidationConfig(BaseModel):
             "If any pattern matches, the bracketed text is treated as literal source "
             "text and preserved during supporting text validation. "
             "If no patterns are configured, all bracketed text is stripped."
+        ),
+    )
+    min_excerpt_length: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Minimum number of non-whitespace characters of quoted text required "
+            "in an excerpt. A short excerpt matches almost any reference by "
+            "chance, so it is weak evidence even when the match succeeds. "
+            "Editorial brackets and '...' separators do not count towards the "
+            "length. Whitespace is ignored so that PDF-to-text extraction "
+            "artifacts do not change the count. Set to 0 to disable the check; "
+            "empty and whitespace-only excerpts are always rejected regardless."
         ),
     )
     reference_prefix_map: dict[str, str] = Field(

--- a/src/linkml_reference_validator/plugins/reference_validation_plugin.py
+++ b/src/linkml_reference_validator/plugins/reference_validation_plugin.py
@@ -16,9 +16,7 @@ from linkml_reference_validator.field_detection import (
 )
 from linkml_reference_validator.models import ReferenceValidationConfig
 from linkml_reference_validator.validation.supporting_text_validator import (
-    EMPTY_SUPPORTING_TEXT_MESSAGE,
     SupportingTextValidator,
-    is_blank_text,
 )
 
 _LINKML_AVAILABLE = (
@@ -192,21 +190,25 @@ if _LINKML_AVAILABLE:
                     f"{path}.{excerpt_field}" if path else excerpt_field
                 )
 
-                # A present-but-blank excerpt is evidence of nothing. It must be
-                # reported here rather than skipped: downstream substring
-                # matching would accept it against any reference, and it may
-                # have no reference at all.
-                if is_blank_text(excerpt_value):
-                    yield LinkMLValidationResult(
-                        type="reference_validation",
-                        severity=Severity.ERROR,
-                        message=f"{EMPTY_SUPPORTING_TEXT_MESSAGE} (in '{excerpt_field}')",
-                        instance={"supporting_text": excerpt_value},
-                        instantiates=excerpt_path,
-                        context=[excerpt_path],
-                        source="ReferenceValidationPlugin",
+                # A present-but-insubstantial excerpt is evidence of nothing. It
+                # must be reported here rather than skipped: downstream
+                # substring matching would accept it against almost any
+                # reference, and it may have no reference at all.
+                if isinstance(excerpt_value, str):
+                    content_problem = self.validator.check_excerpt_content(
+                        excerpt_value
                     )
-                    continue
+                    if content_problem:
+                        yield LinkMLValidationResult(
+                            type="reference_validation",
+                            severity=Severity.ERROR,
+                            message=f"{content_problem} (in '{excerpt_field}')",
+                            instance={"supporting_text": excerpt_value},
+                            instantiates=excerpt_path,
+                            context=[excerpt_path],
+                            source="ReferenceValidationPlugin",
+                        )
+                        continue
 
                 if not excerpt_value:
                     continue

--- a/src/linkml_reference_validator/plugins/reference_validation_plugin.py
+++ b/src/linkml_reference_validator/plugins/reference_validation_plugin.py
@@ -16,7 +16,9 @@ from linkml_reference_validator.field_detection import (
 )
 from linkml_reference_validator.models import ReferenceValidationConfig
 from linkml_reference_validator.validation.supporting_text_validator import (
+    EMPTY_SUPPORTING_TEXT_MESSAGE,
     SupportingTextValidator,
+    is_blank_text,
 )
 
 _LINKML_AVAILABLE = (
@@ -186,6 +188,26 @@ if _LINKML_AVAILABLE:
 
             for excerpt_field in excerpt_fields:
                 excerpt_value = instance.get(excerpt_field)
+                excerpt_path = (
+                    f"{path}.{excerpt_field}" if path else excerpt_field
+                )
+
+                # A present-but-blank excerpt is evidence of nothing. It must be
+                # reported here rather than skipped: downstream substring
+                # matching would accept it against any reference, and it may
+                # have no reference at all.
+                if is_blank_text(excerpt_value):
+                    yield LinkMLValidationResult(
+                        type="reference_validation",
+                        severity=Severity.ERROR,
+                        message=f"{EMPTY_SUPPORTING_TEXT_MESSAGE} (in '{excerpt_field}')",
+                        instance={"supporting_text": excerpt_value},
+                        instantiates=excerpt_path,
+                        context=[excerpt_path],
+                        source="ReferenceValidationPlugin",
+                    )
+                    continue
+
                 if not excerpt_value:
                     continue
 
@@ -208,7 +230,7 @@ if _LINKML_AVAILABLE:
                                 excerpt_value,
                                 reference_id,
                                 expected_title,
-                                f"{path}.{excerpt_field}" if path else excerpt_field,
+                                excerpt_path,
                             )
                             # Break after first successful reference match to avoid duplicates
                             break

--- a/src/linkml_reference_validator/plugins/reference_validation_plugin.py
+++ b/src/linkml_reference_validator/plugins/reference_validation_plugin.py
@@ -186,9 +186,7 @@ if _LINKML_AVAILABLE:
 
             for excerpt_field in excerpt_fields:
                 excerpt_value = instance.get(excerpt_field)
-                excerpt_path = (
-                    f"{path}.{excerpt_field}" if path else excerpt_field
-                )
+                excerpt_path = f"{path}.{excerpt_field}" if path else excerpt_field
 
                 # A present-but-insubstantial excerpt is evidence of nothing. It
                 # must be reported here rather than skipped: downstream
@@ -203,7 +201,7 @@ if _LINKML_AVAILABLE:
                             type="reference_validation",
                             severity=Severity.ERROR,
                             message=f"{content_problem} (in '{excerpt_field}')",
-                            instance={"supporting_text": excerpt_value},
+                            instance={excerpt_field: excerpt_value},
                             instantiates=excerpt_path,
                             context=[excerpt_path],
                             source="ReferenceValidationPlugin",

--- a/src/linkml_reference_validator/validation/repairer.py
+++ b/src/linkml_reference_validator/validation/repairer.py
@@ -42,6 +42,33 @@ from linkml_reference_validator.validation.supporting_text_validator import (
 logger = logging.getLogger(__name__)
 
 
+def _format_excerpt(text: str, limit: int = 60) -> str:
+    """Render an excerpt for a report, marking emptiness and real truncation.
+
+    Args:
+        text: The excerpt as it appears in the data
+        limit: Longest excerpt shown in full
+
+    Returns:
+        A display string
+
+    Examples:
+        >>> _format_excerpt("a short quote")
+        "'a short quote'"
+        >>> _format_excerpt("")
+        '(empty)'
+        >>> _format_excerpt("   ")
+        '(empty)'
+        >>> _format_excerpt("x" * 70).endswith("...'")
+        True
+    """
+    if not text.strip():
+        return "(empty)"
+    if len(text) <= limit:
+        return f"'{text}'"
+    return f"'{text[:limit]}...'"
+
+
 class SupportingTextRepairer:
     """Repair supporting text validation errors.
 
@@ -465,7 +492,7 @@ class SupportingTextRepairer:
             >>> result.is_repaired
             False
             >>> result.actions[0].action_type.value
-            'REMOVAL'
+            'EMPTY_EXCERPT'
         """
         # An insubstantial excerpt carries too little signal to repair from:
         # fuzzy matching it against the reference would invent a quote nobody
@@ -477,8 +504,13 @@ class SupportingTextRepairer:
         # excerpt is a defect in the data that no reference could excuse.
         content_problem = self.validator.check_excerpt_content(supporting_text)
         if content_problem:
+            # EMPTY_EXCERPT, not REMOVAL: a removal recommendation means "this
+            # quote does not match the reference", a verdict reached by
+            # comparison. Nothing was compared here, and reporting it as a
+            # removal would show a meaningless "Similarity: 0%" beside quotes
+            # that really were checked and found fabricated.
             action = RepairAction(
-                action_type=RepairActionType.REMOVAL,
+                action_type=RepairActionType.EMPTY_EXCERPT,
                 original_text=supporting_text,
                 reference_id=reference_id,
                 confidence=RepairConfidence.VERY_LOW,
@@ -594,6 +626,7 @@ class SupportingTextRepairer:
         high_confidence = []
         suggestions = []
         removals = []
+        empty_excerpts = []
         unverifiable = []
         already_valid = []
 
@@ -605,6 +638,8 @@ class SupportingTextRepairer:
             for action in result.actions:
                 if action.can_auto_fix:
                     high_confidence.append((result, action))
+                elif action.action_type == RepairActionType.EMPTY_EXCERPT:
+                    empty_excerpts.append((result, action))
                 elif action.action_type == RepairActionType.REMOVAL:
                     removals.append((result, action))
                 elif action.action_type == RepairActionType.UNVERIFIABLE:
@@ -633,14 +668,26 @@ class SupportingTextRepairer:
                     lines.append(f"    Suggestion: '{action.repaired_text[:80]}...'")
             lines.append("")
 
+        # Empty excerpts - reported before removals, since nothing was compared
+        if empty_excerpts:
+            lines.append("EMPTY EXCERPTS (nothing to verify):")
+            for result, action in empty_excerpts:
+                path_str = f" at {result.path}" if result.path else ""
+                lines.append(f"  {result.reference_id}{path_str}:")
+                lines.append(f"    {result.message}")
+                lines.append(f"    Excerpt: {_format_excerpt(result.original_text)}")
+                lines.append(f"    {action.description}")
+            lines.append("")
+
         # Removals
         if removals:
             lines.append("RECOMMENDED REMOVALS (low confidence):")
             for result, action in removals:
                 path_str = f" at {result.path}" if result.path else ""
                 lines.append(f"  {result.reference_id}{path_str}:")
+                lines.append(f"    {action.description}")
                 lines.append(f"    Similarity: {action.similarity_score*100:.0f}%")
-                lines.append(f"    Snippet: '{result.original_text[:60]}...'")
+                lines.append(f"    Snippet: {_format_excerpt(result.original_text)}")
             lines.append("")
 
         # Unverifiable
@@ -660,6 +707,7 @@ class SupportingTextRepairer:
         lines.append(f"  Auto-fixes: {report.auto_fixed_count}")
         lines.append(f"  Suggestions: {report.suggested_count}")
         lines.append(f"  Removals: {report.removal_count}")
+        lines.append(f"  Empty excerpts: {report.empty_excerpt_count}")
         lines.append(f"  Unverifiable: {report.unverifiable_count}")
 
         return "\n".join(lines)

--- a/src/linkml_reference_validator/validation/repairer.py
+++ b/src/linkml_reference_validator/validation/repairer.py
@@ -36,9 +36,7 @@ from linkml_reference_validator.validation.fuzzy_text_utils import (
     normalize_whitespace,
 )
 from linkml_reference_validator.validation.supporting_text_validator import (
-    EMPTY_SUPPORTING_TEXT_MESSAGE,
     SupportingTextValidator,
-    is_blank_text,
 )
 
 logger = logging.getLogger(__name__)
@@ -469,10 +467,11 @@ class SupportingTextRepairer:
             >>> result.actions[0].action_type.value
             'REMOVAL'
         """
-        # A blank excerpt carries no signal to repair from: fuzzy matching it
-        # against the reference would invent a quote nobody wrote. Flag it for
-        # human review instead, without fetching anything.
-        if is_blank_text(supporting_text):
+        # An insubstantial excerpt carries too little signal to repair from:
+        # fuzzy matching it against the reference would invent a quote nobody
+        # wrote. Flag it for human review instead, without fetching anything.
+        content_problem = self.validator.check_excerpt_content(supporting_text)
+        if content_problem:
             return RepairResult(
                 reference_id=reference_id,
                 original_text=supporting_text,
@@ -483,10 +482,10 @@ class SupportingTextRepairer:
                     original_text=supporting_text,
                     reference_id=reference_id,
                     confidence=RepairConfidence.VERY_LOW,
-                    description="Excerpt is empty - supply a real quote or remove the item",
+                    description="Supply a real quote from the reference, or remove the item",
                     path=path,
                 )],
-                message=f"{EMPTY_SUPPORTING_TEXT_MESSAGE} - cannot be repaired automatically",
+                message=f"{content_problem} - cannot be repaired automatically",
                 path=path,
             )
 

--- a/src/linkml_reference_validator/validation/repairer.py
+++ b/src/linkml_reference_validator/validation/repairer.py
@@ -36,7 +36,9 @@ from linkml_reference_validator.validation.fuzzy_text_utils import (
     normalize_whitespace,
 )
 from linkml_reference_validator.validation.supporting_text_validator import (
+    EMPTY_SUPPORTING_TEXT_MESSAGE,
     SupportingTextValidator,
+    is_blank_text,
 )
 
 logger = logging.getLogger(__name__)
@@ -460,7 +462,34 @@ class SupportingTextRepairer:
             >>> # In real usage:
             >>> # repairer = SupportingTextRepairer(ReferenceValidationConfig())
             >>> # result = repairer.repair_single("some text", "PMID:123")
+            >>> repairer = SupportingTextRepairer(ReferenceValidationConfig())
+            >>> result = repairer.repair_single("", "PMID:123")
+            >>> result.is_repaired
+            False
+            >>> result.actions[0].action_type.value
+            'REMOVAL'
         """
+        # A blank excerpt carries no signal to repair from: fuzzy matching it
+        # against the reference would invent a quote nobody wrote. Flag it for
+        # human review instead, without fetching anything.
+        if is_blank_text(supporting_text):
+            return RepairResult(
+                reference_id=reference_id,
+                original_text=supporting_text,
+                was_valid=False,
+                is_repaired=False,
+                actions=[RepairAction(
+                    action_type=RepairActionType.REMOVAL,
+                    original_text=supporting_text,
+                    reference_id=reference_id,
+                    confidence=RepairConfidence.VERY_LOW,
+                    description="Excerpt is empty - supply a real quote or remove the item",
+                    path=path,
+                )],
+                message=f"{EMPTY_SUPPORTING_TEXT_MESSAGE} - cannot be repaired automatically",
+                path=path,
+            )
+
         # Check skip list
         if reference_id in self.repair_config.skip_references:
             return RepairResult(

--- a/src/linkml_reference_validator/validation/repairer.py
+++ b/src/linkml_reference_validator/validation/repairer.py
@@ -492,7 +492,7 @@ class SupportingTextRepairer:
             >>> result.is_repaired
             False
             >>> result.actions[0].action_type.value
-            'EMPTY_EXCERPT'
+            'INSUFFICIENT_EXCERPT'
         """
         # An insubstantial excerpt carries too little signal to repair from:
         # fuzzy matching it against the reference would invent a quote nobody
@@ -504,13 +504,13 @@ class SupportingTextRepairer:
         # excerpt is a defect in the data that no reference could excuse.
         content_problem = self.validator.check_excerpt_content(supporting_text)
         if content_problem:
-            # EMPTY_EXCERPT, not REMOVAL: a removal recommendation means "this
+            # INSUFFICIENT_EXCERPT, not REMOVAL: a removal recommendation means "this
             # quote does not match the reference", a verdict reached by
             # comparison. Nothing was compared here, and reporting it as a
             # removal would show a meaningless "Similarity: 0%" beside quotes
             # that really were checked and found fabricated.
             action = RepairAction(
-                action_type=RepairActionType.EMPTY_EXCERPT,
+                action_type=RepairActionType.INSUFFICIENT_EXCERPT,
                 original_text=supporting_text,
                 reference_id=reference_id,
                 confidence=RepairConfidence.VERY_LOW,
@@ -626,7 +626,7 @@ class SupportingTextRepairer:
         high_confidence = []
         suggestions = []
         removals = []
-        empty_excerpts = []
+        insufficient_excerpts = []
         unverifiable = []
         already_valid = []
 
@@ -638,8 +638,8 @@ class SupportingTextRepairer:
             for action in result.actions:
                 if action.can_auto_fix:
                     high_confidence.append((result, action))
-                elif action.action_type == RepairActionType.EMPTY_EXCERPT:
-                    empty_excerpts.append((result, action))
+                elif action.action_type == RepairActionType.INSUFFICIENT_EXCERPT:
+                    insufficient_excerpts.append((result, action))
                 elif action.action_type == RepairActionType.REMOVAL:
                     removals.append((result, action))
                 elif action.action_type == RepairActionType.UNVERIFIABLE:
@@ -668,10 +668,10 @@ class SupportingTextRepairer:
                     lines.append(f"    Suggestion: '{action.repaired_text[:80]}...'")
             lines.append("")
 
-        # Empty excerpts - reported before removals, since nothing was compared
-        if empty_excerpts:
-            lines.append("EMPTY EXCERPTS (nothing to verify):")
-            for result, action in empty_excerpts:
+        # Reported before removals, since nothing here was compared at all
+        if insufficient_excerpts:
+            lines.append("INSUFFICIENT EXCERPTS (nothing to verify):")
+            for result, action in insufficient_excerpts:
                 path_str = f" at {result.path}" if result.path else ""
                 lines.append(f"  {result.reference_id}{path_str}:")
                 lines.append(f"    {result.message}")
@@ -707,7 +707,7 @@ class SupportingTextRepairer:
         lines.append(f"  Auto-fixes: {report.auto_fixed_count}")
         lines.append(f"  Suggestions: {report.suggested_count}")
         lines.append(f"  Removals: {report.removal_count}")
-        lines.append(f"  Empty excerpts: {report.empty_excerpt_count}")
+        lines.append(f"  Insufficient excerpts: {report.insufficient_excerpt_count}")
         lines.append(f"  Unverifiable: {report.unverifiable_count}")
 
         return "\n".join(lines)

--- a/src/linkml_reference_validator/validation/repairer.py
+++ b/src/linkml_reference_validator/validation/repairer.py
@@ -470,21 +470,27 @@ class SupportingTextRepairer:
         # An insubstantial excerpt carries too little signal to repair from:
         # fuzzy matching it against the reference would invent a quote nobody
         # wrote. Flag it for human review instead, without fetching anything.
+        #
+        # Deliberately ahead of skip_references and trusted_low_similarity.
+        # Both of those settings are statements about a *reference* - do not
+        # chase it, do not doubt quotes that match it poorly - whereas a blank
+        # excerpt is a defect in the data that no reference could excuse.
         content_problem = self.validator.check_excerpt_content(supporting_text)
         if content_problem:
+            action = RepairAction(
+                action_type=RepairActionType.REMOVAL,
+                original_text=supporting_text,
+                reference_id=reference_id,
+                confidence=RepairConfidence.VERY_LOW,
+                description="Supply a real quote from the reference, or remove the item",
+                path=path,
+            )
             return RepairResult(
                 reference_id=reference_id,
                 original_text=supporting_text,
                 was_valid=False,
                 is_repaired=False,
-                actions=[RepairAction(
-                    action_type=RepairActionType.REMOVAL,
-                    original_text=supporting_text,
-                    reference_id=reference_id,
-                    confidence=RepairConfidence.VERY_LOW,
-                    description="Supply a real quote from the reference, or remove the item",
-                    path=path,
-                )],
+                actions=[action],
                 message=f"{content_problem} - cannot be repaired automatically",
                 path=path,
             )

--- a/src/linkml_reference_validator/validation/supporting_text_validator.py
+++ b/src/linkml_reference_validator/validation/supporting_text_validator.py
@@ -200,15 +200,16 @@ class SupportingTextValidator:
             >>> result.is_valid
             False
         """
-        # A blank excerpt is a defect in the data regardless of what it cites,
-        # so reject it before skip-prefix handling or any reference lookup.
-        if is_blank_text(supporting_text):
+        # An insubstantial excerpt is a defect in the data regardless of what it
+        # cites, so reject it before skip-prefix handling or any lookup.
+        content_problem = self.check_excerpt_content(supporting_text)
+        if content_problem:
             return ValidationResult(
                 is_valid=False,
                 reference_id=reference_id,
                 supporting_text=supporting_text,
                 severity=ValidationSeverity.ERROR,
-                message=f"{EMPTY_SUPPORTING_TEXT_MESSAGE}: {reference_id}",
+                message=f"{content_problem}: {reference_id}",
                 path=path,
             )
 
@@ -324,12 +325,13 @@ class SupportingTextValidator:
             >>> validator.find_text_in_reference("", ref).found
             False
         """
-        # Checked before content, so a blank excerpt is always diagnosed as
-        # blank rather than blamed on the reference.
-        if is_blank_text(supporting_text):
+        # Checked before content, so a thin excerpt is always diagnosed as thin
+        # rather than blamed on the reference.
+        content_problem = self.check_excerpt_content(supporting_text)
+        if content_problem:
             return SupportingTextMatch(
                 found=False,
-                error_message=EMPTY_SUPPORTING_TEXT_MESSAGE,
+                error_message=content_problem,
             )
 
         if not reference.content:
@@ -388,6 +390,79 @@ class SupportingTextValidator:
         parts = re.split(r"\s*\.{2,}\s*", text_without_brackets)
         parts = [re.sub(r"\s+", " ", p).strip() for p in parts if p.strip()]
         return parts
+
+    def count_quoted_characters(self, supporting_text: str) -> int:
+        """Count the non-whitespace characters an excerpt actually quotes.
+
+        Editorial brackets and ``...`` separators are excluded because they are
+        never matched against the reference. Whitespace is excluded so that
+        PDF-to-text extraction artifacts ("t he pro tein") measure the same as
+        clean text, and so that no tokenizing is needed - chemical nomenclature
+        and other punctuation-dense strings are counted in full.
+
+        Args:
+            supporting_text: The excerpt to measure
+
+        Returns:
+            Number of non-whitespace characters of quoted text
+
+        Examples:
+            >>> config = ReferenceValidationConfig()
+            >>> validator = SupportingTextValidator(config)
+            >>> validator.count_quoted_characters("the protein")
+            10
+            >>> validator.count_quoted_characters("t he pro tein")
+            10
+            >>> validator.count_quoted_characters("protein [important] functions")
+            16
+            >>> validator.count_quoted_characters("2,3-dihydroxybenzoate")
+            21
+        """
+        return sum(
+            len(re.sub(r"\s", "", part))
+            for part in self._split_query(supporting_text)
+        )
+
+    def check_excerpt_content(self, supporting_text: str) -> Optional[str]:
+        """Report why an excerpt is too insubstantial to be evidence, if it is.
+
+        Applied before any reference is fetched, because these are defects in
+        the data itself: they hold regardless of what the excerpt cites, and no
+        lookup could change the verdict.
+
+        Args:
+            supporting_text: The excerpt to check
+
+        Returns:
+            An error message, or None if the excerpt has enough substance
+
+        Examples:
+            >>> config = ReferenceValidationConfig()
+            >>> validator = SupportingTextValidator(config)
+            >>> validator.check_excerpt_content("protein functions") is None
+            True
+            >>> "empty" in validator.check_excerpt_content("   ")
+            True
+            >>> strict = ReferenceValidationConfig(min_excerpt_length=20)
+            >>> validator = SupportingTextValidator(strict)
+            >>> "too short" in validator.check_excerpt_content("the gene")
+            True
+        """
+        if is_blank_text(supporting_text):
+            return EMPTY_SUPPORTING_TEXT_MESSAGE
+
+        if self.config.min_excerpt_length <= 0:
+            return None
+
+        length = self.count_quoted_characters(supporting_text)
+        if length < self.config.min_excerpt_length:
+            return (
+                f"Supporting text is too short: {length} non-whitespace "
+                f"characters of quoted text, minimum is "
+                f"{self.config.min_excerpt_length} (min_excerpt_length)"
+            )
+
+        return None
 
     def _substring_match(
         self,

--- a/src/linkml_reference_validator/validation/supporting_text_validator.py
+++ b/src/linkml_reference_validator/validation/supporting_text_validator.py
@@ -348,14 +348,6 @@ class SupportingTextValidator:
             )
 
         query_parts = self._split_query(supporting_text)
-
-        # Empty query validation
-        if not query_parts:
-            return SupportingTextMatch(
-                found=False,
-                error_message="Query is empty after removing brackets and splitting",
-            )
-
         return self._substring_match(query_parts, reference.content, supporting_text)
 
     def _split_query(self, text: str) -> list[str]:
@@ -509,7 +501,20 @@ class SupportingTextValidator:
             True
             >>> match.similarity_score
             1.0
+            >>> validator._substring_match([], "any document at all").found
+            False
         """
+        # Guarded here rather than in the caller: with no parts the loop below
+        # never runs and every quote "matches", which is the vacuous pass this
+        # whole check exists to prevent. check_excerpt_content already rejects
+        # such excerpts upstream, so this is the invariant that keeps the
+        # primitive honest if it is ever called from somewhere else.
+        if not query_parts:
+            return SupportingTextMatch(
+                found=False,
+                error_message=NO_QUOTED_TEXT_MESSAGE,
+            )
+
         normalized_content = self.normalize_text(content)
         matched_parts = []
 

--- a/src/linkml_reference_validator/validation/supporting_text_validator.py
+++ b/src/linkml_reference_validator/validation/supporting_text_validator.py
@@ -15,6 +15,39 @@ from linkml_reference_validator.models import (
 
 logger = logging.getLogger(__name__)
 
+#: Message used whenever a blank excerpt is rejected, so every layer reports
+#: the same diagnosis for the same defect.
+EMPTY_SUPPORTING_TEXT_MESSAGE = (
+    "Supporting text is empty: an excerpt must quote actual text from the "
+    "reference (the empty string trivially matches any document)"
+)
+
+
+def is_blank_text(value: object) -> bool:
+    """Report whether a value is a string with no non-whitespace characters.
+
+    Blank excerpts are the core of the "vacuous pass" bug: substring checks
+    succeed for the empty string against every possible document, so a blank
+    excerpt would otherwise be recorded as verified evidence.
+
+    Args:
+        value: Value to test; non-strings are never blank text
+
+    Returns:
+        True if the value is a string containing only whitespace (or nothing)
+
+    Examples:
+        >>> is_blank_text("")
+        True
+        >>> is_blank_text("   \\n")
+        True
+        >>> is_blank_text("protein functions")
+        False
+        >>> is_blank_text(None)
+        False
+    """
+    return isinstance(value, str) and not value.strip()
+
 
 class SupportingTextValidator:
     """Validate that supporting text quotes are found in references.
@@ -162,7 +195,23 @@ class SupportingTextValidator:
             >>> # result = validator.validate("quote", "PMID:12345678")
             >>> # With title validation:
             >>> # result = validator.validate("quote", "PMID:12345678", expected_title="Study Title")
+            >>> # A blank excerpt is rejected without any reference lookup:
+            >>> result = validator.validate("   ", "PMID:12345678")
+            >>> result.is_valid
+            False
         """
+        # A blank excerpt is a defect in the data regardless of what it cites,
+        # so reject it before skip-prefix handling or any reference lookup.
+        if is_blank_text(supporting_text):
+            return ValidationResult(
+                is_valid=False,
+                reference_id=reference_id,
+                supporting_text=supporting_text,
+                severity=ValidationSeverity.ERROR,
+                message=f"{EMPTY_SUPPORTING_TEXT_MESSAGE}: {reference_id}",
+                path=path,
+            )
+
         # Check if this prefix should be skipped
         prefix = reference_id.split(":")[0].upper() if ":" in reference_id else ""
         skip_prefixes_upper = [p.upper() for p in self.config.skip_prefixes]
@@ -272,7 +321,17 @@ class SupportingTextValidator:
             ... )
             >>> match.found
             True
+            >>> validator.find_text_in_reference("", ref).found
+            False
         """
+        # Checked before content, so a blank excerpt is always diagnosed as
+        # blank rather than blamed on the reference.
+        if is_blank_text(supporting_text):
+            return SupportingTextMatch(
+                found=False,
+                error_message=EMPTY_SUPPORTING_TEXT_MESSAGE,
+            )
+
         if not reference.content:
             return SupportingTextMatch(
                 found=False,

--- a/src/linkml_reference_validator/validation/supporting_text_validator.py
+++ b/src/linkml_reference_validator/validation/supporting_text_validator.py
@@ -22,6 +22,13 @@ EMPTY_SUPPORTING_TEXT_MESSAGE = (
     "reference (the empty string trivially matches any document)"
 )
 
+#: An excerpt made only of editorial notes and ellipses quotes nothing, so it
+#: is exactly as vacuous as a blank one and is diagnosed the same way.
+NO_QUOTED_TEXT_MESSAGE = (
+    "Supporting text is empty once editorial brackets and '...' separators are "
+    "removed: it quotes nothing from the reference"
+)
+
 
 def is_blank_text(value: object) -> bool:
     """Report whether a value is a string with no non-whitespace characters.
@@ -443,6 +450,8 @@ class SupportingTextValidator:
             True
             >>> "empty" in validator.check_excerpt_content("   ")
             True
+            >>> "empty" in validator.check_excerpt_content("[editorial note]")
+            True
             >>> strict = ReferenceValidationConfig(min_excerpt_length=20)
             >>> validator = SupportingTextValidator(strict)
             >>> "too short" in validator.check_excerpt_content("the gene")
@@ -451,10 +460,16 @@ class SupportingTextValidator:
         if is_blank_text(supporting_text):
             return EMPTY_SUPPORTING_TEXT_MESSAGE
 
+        length = self.count_quoted_characters(supporting_text)
+
+        # Independent of min_excerpt_length: an excerpt that quotes nothing is
+        # the defect this check exists for, not a threshold judgement.
+        if length == 0:
+            return NO_QUOTED_TEXT_MESSAGE
+
         if self.config.min_excerpt_length <= 0:
             return None
 
-        length = self.count_quoted_characters(supporting_text)
         if length < self.config.min_excerpt_length:
             return (
                 f"Supporting text is too short: {length} non-whitespace "

--- a/tests/fixtures/CLINICALTRIALS_NCT00000001.md
+++ b/tests/fixtures/CLINICALTRIALS_NCT00000001.md
@@ -1,5 +1,6 @@
 ---
 reference_id: clinicaltrials:NCT00000001
+extractor_version: 1
 title: A Phase III Study of Drug X for Treatment of Disease Y
 content_type: summary
 ---

--- a/tests/fixtures/GEO_GSE12345.md
+++ b/tests/fixtures/GEO_GSE12345.md
@@ -1,5 +1,6 @@
 ---
 reference_id: GEO:GSE12345
+extractor_version: 1
 title: Test GEO Dataset for Validation
 content_type: summary
 ---

--- a/tests/fixtures/PMC_TEST001.md
+++ b/tests/fixtures/PMC_TEST001.md
@@ -1,5 +1,6 @@
 ---
 reference_id: PMC:TEST001
+extractor_version: 1
 title: Molecular mechanisms of BRCA1 in DNA repair
 authors:
 - Zhang L

--- a/tests/fixtures/PMC_TEST002.md
+++ b/tests/fixtures/PMC_TEST002.md
@@ -1,5 +1,6 @@
 ---
 reference_id: PMC:TEST002
+extractor_version: 1
 title: TP53 mutations in cancer development
 authors:
 - Johnson K

--- a/tests/fixtures/PMID_TEST001.md
+++ b/tests/fixtures/PMID_TEST001.md
@@ -1,5 +1,6 @@
 ---
 reference_id: PMID:TEST001
+extractor_version: 1
 title: Protein X functions in cell cycle regulation
 authors:
 - Smith J

--- a/tests/fixtures/PMID_TEST002.md
+++ b/tests/fixtures/PMID_TEST002.md
@@ -1,5 +1,6 @@
 ---
 reference_id: PMID:TEST002
+extractor_version: 1
 title: Role of Protein Y in apoptosis pathway
 authors:
 - Brown M

--- a/tests/fixtures/PMID_TEST003.md
+++ b/tests/fixtures/PMID_TEST003.md
@@ -1,5 +1,6 @@
 ---
 reference_id: PMID:TEST003
+extractor_version: 1
 title: Comprehensive analysis of gene Z expression patterns
 authors:
 - Garcia L

--- a/tests/test_cli_repair.py
+++ b/tests/test_cli_repair.py
@@ -468,3 +468,97 @@ def test_repair_data_help():
     result = runner.invoke(app, ["repair", "data", "--help"])
     assert result.exit_code == 0
     assert "data file" in result.stdout.lower()
+
+
+# ============================================================================
+# Exit status for substantively empty excerpts
+#
+# An empty excerpt must fail the command, not just appear in the report body:
+# CI jobs gate on the exit status, and a green run on exactly the defect the
+# validator exists to catch is worse than no check at all.
+# ============================================================================
+
+
+_EMPTY_EXCERPT_SCHEMA = """
+id: https://example.org/test
+name: test
+default_prefix: test
+
+classes:
+  Statement:
+    tree_root: true
+    attributes:
+      text:
+        range: string
+      evidence:
+        multivalued: true
+        range: Evidence
+
+  Evidence:
+    attributes:
+      reference:
+        range: string
+      supporting_text:
+        range: string
+"""
+
+
+def test_repair_data_exits_nonzero_for_empty_excerpt(tmp_path, cli_cache_dir):
+    """A file whose only defect is an empty excerpt must exit non-zero."""
+    schema_file = tmp_path / "schema.yaml"
+    schema_file.write_text(_EMPTY_EXCERPT_SCHEMA)
+
+    data_file = tmp_path / "data.yaml"
+    data_file.write_text(
+        'text: "Test statement"\n'
+        "evidence:\n"
+        '  - reference: "PMID:TEST001"\n'
+        '    supporting_text: ""\n'
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "repair",
+            "data",
+            str(data_file),
+            "--schema",
+            str(schema_file),
+            "--cache-dir",
+            str(cli_cache_dir),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Manual review required" in result.stdout
+
+
+def test_repair_data_exits_zero_when_all_excerpts_valid(tmp_path, cli_cache_dir):
+    """The check above must not make clean files fail."""
+    schema_file = tmp_path / "schema.yaml"
+    schema_file.write_text(_EMPTY_EXCERPT_SCHEMA)
+
+    data_file = tmp_path / "data.yaml"
+    data_file.write_text(
+        'text: "Test statement"\n'
+        "evidence:\n"
+        '  - reference: "PMID:TEST001"\n'
+        '    supporting_text: "Protein X functions in cell cycle regulation"\n'
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "repair",
+            "data",
+            str(data_file),
+            "--schema",
+            str(schema_file),
+            "--cache-dir",
+            str(cli_cache_dir),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0

--- a/tests/test_cli_repair.py
+++ b/tests/test_cli_repair.py
@@ -562,3 +562,43 @@ def test_repair_data_exits_zero_when_all_excerpts_valid(tmp_path, cli_cache_dir)
     )
 
     assert result.exit_code == 0
+
+
+def test_repair_text_empty_omits_meaningless_similarity(cli_cache_dir):
+    """No comparison happened, so no percentage should be shown for it.
+
+    format_report drops the similarity line for these; this command must
+    agree rather than printing "VERY_LOW (0%)" for a quote that was never
+    compared against anything.
+    """
+    result = runner.invoke(
+        app,
+        [
+            "repair",
+            "text",
+            "",
+            "PMID:TEST001",
+            "--cache-dir",
+            str(cli_cache_dir),
+        ],
+    )
+
+    assert "0%" not in result.stdout
+    assert "INSUFFICIENT_EXCERPT" in result.stdout
+
+
+def test_repair_text_keeps_similarity_for_compared_quotes(cli_cache_dir):
+    """A quote that really was compared still reports its score."""
+    result = runner.invoke(
+        app,
+        [
+            "repair",
+            "text",
+            "a wholly fabricated sentence that is not in the paper",
+            "PMID:TEST001",
+            "--cache-dir",
+            str(cli_cache_dir),
+        ],
+    )
+
+    assert "%" in result.stdout

--- a/tests/test_empty_snippets.py
+++ b/tests/test_empty_snippets.py
@@ -339,13 +339,14 @@ def test_report_shows_empty_excerpt_distinctly(cached_config):
     report = repairer.repair_batch([("", "PMID:TEST001", "evidence[0].snippet")])
 
     output = repairer.format_report(report)
-    section = output.split("INSUFFICIENT EXCERPTS")[1].split("Summary:")[0]
+    section = output.split("INSUFFICIENT EXCERPTS")[1].split("RECOMMENDED REMOVALS")[0]
 
     assert "Excerpt: (empty)" in section
     assert "evidence[0].snippet" in section
-    # Scoped to the section: a similarity score is meaningful for quotes that
-    # really were compared, so the assertion must not depend on the batch
-    # happening to contain none of those.
+    # Scoped to this section alone - the removals section that follows it is
+    # cut off deliberately. A similarity score is meaningful for quotes that
+    # really were compared, so this assertion must not start failing merely
+    # because a fabricated quote joins the batch.
     assert "Similarity" not in section
 
 

--- a/tests/test_empty_snippets.py
+++ b/tests/test_empty_snippets.py
@@ -632,3 +632,101 @@ def test_repair_single_flags_too_short_for_removal(cached_config):
     assert result.is_repaired is False
     assert [a.action_type for a in result.actions] == [RepairActionType.INSUFFICIENT_EXCERPT]
     assert "too short" in result.message.lower()
+
+
+# ---------------------------------------------------------------------------
+# The repair CLI must write a fix back to the key it read the quote from
+# ---------------------------------------------------------------------------
+
+
+def test_repair_writes_back_to_the_key_it_read_from():
+    """Extraction prefers the non-blank key; write-back must agree.
+
+    With supporting_text blank and snippet holding the real quote, a repair
+    of the snippet used to be written into supporting_text, leaving the
+    snippet wrong and inventing a quote in a field that had none.
+    """
+    from linkml_reference_validator.cli.repair import (
+        _apply_repairs_to_data,
+        _excerpt_key,
+    )
+    from linkml_reference_validator.models import (
+        RepairAction,
+        RepairConfidence,
+        RepairReport,
+        RepairResult,
+    )
+
+    data = {
+        "evidence": [
+            {"reference": "PMID:TEST001", "supporting_text": "", "snippet": "CO2 levels"}
+        ]
+    }
+    assert _excerpt_key(data["evidence"][0]) == "snippet"
+
+    report = RepairReport()
+    report.add_result(
+        RepairResult(
+            reference_id="PMID:TEST001",
+            original_text="CO2 levels",
+            was_valid=False,
+            is_repaired=True,
+            repaired_text="CO₂ levels",
+            path="evidence[0]",
+            actions=[
+                RepairAction(
+                    action_type=RepairActionType.CHARACTER_NORMALIZATION,
+                    original_text="CO2 levels",
+                    repaired_text="CO₂ levels",
+                    confidence=RepairConfidence.HIGH,
+                )
+            ],
+        )
+    )
+
+    changed = _apply_repairs_to_data(data, report, None)
+
+    assert changed is True
+    assert data["evidence"][0]["snippet"] == "CO₂ levels"
+    assert data["evidence"][0]["supporting_text"] == ""
+
+
+def test_repair_writes_back_to_supporting_text_when_it_holds_the_quote():
+    """The ordinary case still writes to supporting_text."""
+    from linkml_reference_validator.cli.repair import (
+        _apply_repairs_to_data,
+        _excerpt_key,
+    )
+    from linkml_reference_validator.models import (
+        RepairAction,
+        RepairConfidence,
+        RepairReport,
+        RepairResult,
+    )
+
+    data = {"evidence": [{"reference": "PMID:TEST001", "supporting_text": "CO2 levels"}]}
+    assert _excerpt_key(data["evidence"][0]) == "supporting_text"
+
+    report = RepairReport()
+    report.add_result(
+        RepairResult(
+            reference_id="PMID:TEST001",
+            original_text="CO2 levels",
+            was_valid=False,
+            is_repaired=True,
+            repaired_text="CO₂ levels",
+            path="evidence[0]",
+            actions=[
+                RepairAction(
+                    action_type=RepairActionType.CHARACTER_NORMALIZATION,
+                    original_text="CO2 levels",
+                    repaired_text="CO₂ levels",
+                    confidence=RepairConfidence.HIGH,
+                )
+            ],
+        )
+    )
+
+    _apply_repairs_to_data(data, report, None)
+
+    assert data["evidence"][0]["supporting_text"] == "CO₂ levels"

--- a/tests/test_empty_snippets.py
+++ b/tests/test_empty_snippets.py
@@ -36,6 +36,8 @@ from linkml_reference_validator.validation.supporting_text_validator import (
     is_blank_text,
 )
 
+MIN_LENGTH = 20
+
 DATA_DIR = Path(__file__).parent / "data"
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 DEEP_SCHEMA = DATA_DIR / "test_schema_deep_nesting.yaml"
@@ -330,3 +332,149 @@ def test_extract_evidence_items_requires_reference():
     items = _extract_evidence_items(data, None, Path("unused.yaml"))
 
     assert items == []
+
+
+# ---------------------------------------------------------------------------
+# Configurable minimum excerpt length
+#
+# A blank excerpt is the extreme case; a two-character one is barely better,
+# since a short string matches almost any paper by chance. Length is measured
+# in non-whitespace characters of quoted text, which keeps the count stable
+# across PDF-to-text whitespace damage and never splits chemical names.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def strict_config(tmp_path):
+    """Configuration enforcing a minimum excerpt length."""
+    return ReferenceValidationConfig(
+        cache_dir=tmp_path / "cache",
+        rate_limit_delay=0.0,
+        min_excerpt_length=MIN_LENGTH,
+    )
+
+
+def test_min_excerpt_length_defaults_to_disabled():
+    """The check is opt-in so existing data keeps validating as before."""
+    assert ReferenceValidationConfig().min_excerpt_length == 0
+
+
+def test_min_excerpt_length_rejects_negative():
+    """A negative minimum is meaningless."""
+    with pytest.raises(ValueError):
+        ReferenceValidationConfig(min_excerpt_length=-1)
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("the protein", 10),
+        # PDF-to-text whitespace damage must not change the count.
+        ("t he pro tein", 10),
+        ("the\n\nprotein", 10),
+        # Editorial brackets are not quoted text.
+        ("protein [important] functions", len("proteinfunctions")),
+        # Ellipsis separators are not quoted text.
+        ("abc ... def", 6),
+        ("[editorial note only]", 0),
+        ("", 0),
+        # Chemical nomenclature counts in full - no tokenizing, no splitting.
+        ("2,3-dihydroxybenzoate", 21),
+        ("N-(4-hydroxyphenyl)acetamide", 28),
+    ],
+)
+def test_count_quoted_characters(validator, text, expected):
+    """Length counts non-whitespace characters of actually-quoted text."""
+    assert validator.count_quoted_characters(text) == expected
+
+
+def test_count_quoted_characters_survives_whitespace_damage(validator):
+    """Mangled and clean renderings of the same quote measure identically."""
+    clean = "the protein functions in cell cycle"
+    mangled = "the  pro tein  func tions\tin cell   cycle"
+
+    assert validator.count_quoted_characters(clean) == validator.count_quoted_characters(
+        mangled
+    )
+
+
+def test_validate_rejects_too_short_excerpt(strict_config):
+    """An excerpt below the configured minimum is an error."""
+    validator = SupportingTextValidator(strict_config)
+
+    result = validator.validate("the gene", "PMID:TEST001")
+
+    assert result.is_valid is False
+    assert result.severity == ValidationSeverity.ERROR
+    assert "too short" in result.message.lower()
+    assert str(MIN_LENGTH) in result.message
+
+
+def test_validate_too_short_does_not_fetch(strict_config, mocker):
+    """A too-short excerpt fails without any reference lookup."""
+    validator = SupportingTextValidator(strict_config)
+    spy = mocker.patch.object(validator.fetcher, "fetch")
+
+    validator.validate("the gene", "PMID:TEST001")
+
+    spy.assert_not_called()
+
+
+def test_validate_accepts_excerpt_at_minimum(cached_config):
+    """An excerpt meeting the minimum validates normally."""
+    text = "Protein X functions in cell cycle regulation"
+    cached_config.min_excerpt_length = len(text.replace(" ", ""))
+    validator = SupportingTextValidator(cached_config)
+
+    result = validator.validate(text, "PMID:TEST001")
+
+    assert result.is_valid is True
+
+
+def test_short_excerpt_allowed_when_check_disabled(cached_config):
+    """With the default config, a short but real quote still passes."""
+    validator = SupportingTextValidator(cached_config)
+
+    result = validator.validate("Protein X", "PMID:TEST001")
+
+    assert result.is_valid is True
+
+
+def test_find_text_in_reference_rejects_too_short(strict_config):
+    """The matching entry point enforces the minimum too."""
+    validator = SupportingTextValidator(strict_config)
+    ref = ReferenceContent(
+        reference_id="PMID:123",
+        content="The protein functions in cell cycle regulation.",
+    )
+
+    match = validator.find_text_in_reference("protein", ref)
+
+    assert match.found is False
+    assert "too short" in match.error_message.lower()
+
+
+def test_plugin_rejects_too_short_snippet(cached_config):
+    """The plugin reports a too-short snippet like any other empty evidence."""
+    cached_config.min_excerpt_length = MIN_LENGTH
+    plugin = ReferenceValidationPlugin(config=cached_config)
+    schema_view = SchemaView(str(DEEP_SCHEMA))
+    context = ValidationContext(schema_view.schema, target_class="Community")
+    plugin.pre_process(context)
+
+    results = list(plugin.process(_community({"snippet": "the gene"}), context))
+
+    assert len(results) == 1
+    assert "too short" in results[0].message.lower()
+
+
+def test_repair_single_flags_too_short_for_removal(cached_config):
+    """A too-short excerpt cannot be repaired - there is nothing to expand from."""
+    cached_config.min_excerpt_length = MIN_LENGTH
+    repairer = SupportingTextRepairer(cached_config, RepairConfig())
+
+    result = repairer.repair_single("the gene", "PMID:TEST001")
+
+    assert result.is_repaired is False
+    assert [a.action_type for a in result.actions] == [RepairActionType.REMOVAL]
+    assert "too short" in result.message.lower()

--- a/tests/test_empty_snippets.py
+++ b/tests/test_empty_snippets.py
@@ -117,6 +117,50 @@ def test_is_blank_text_false(text):
     assert is_blank_text(text) is False
 
 
+# ---------------------------------------------------------------------------
+# Excerpts that are non-blank but still quote nothing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("text", ["...", "....", "[editorial note]", "[a] ... [b]"])
+def test_validate_rejects_excerpt_quoting_nothing(validator, text):
+    """Markup that reduces to no quoted text is as vacuous as a blank string."""
+    result = validator.validate(text, "PMID:TEST001")
+
+    assert result.is_valid is False
+    assert result.severity == ValidationSeverity.ERROR
+    assert "empty" in result.message.lower()
+
+
+def test_validate_excerpt_quoting_nothing_does_not_fetch(validator, mocker):
+    """It is a data defect, so it is settled without a reference lookup."""
+    spy = mocker.patch.object(validator.fetcher, "fetch")
+
+    validator.validate("[editorial note]", "PMID:TEST001")
+
+    spy.assert_not_called()
+
+
+def test_plugin_rejects_snippet_quoting_nothing(plugin, deep_context):
+    """The plugin reports bracket-only snippets like any other empty evidence."""
+    results = list(
+        plugin.process(_community({"snippet": "[not a real quote]"}), deep_context)
+    )
+
+    assert len(results) == 1
+    assert "empty" in results[0].message.lower()
+
+
+def test_repair_single_flags_excerpt_quoting_nothing(cached_config):
+    """A bracket-only excerpt is flagged for removal, not repaired."""
+    repairer = SupportingTextRepairer(cached_config, RepairConfig())
+
+    result = repairer.repair_single("[editorial note]", "PMID:TEST001")
+
+    assert result.is_repaired is False
+    assert [a.action_type for a in result.actions] == [RepairActionType.REMOVAL]
+
+
 def test_is_blank_text_non_string():
     """Non-strings are not blank text (they are handled elsewhere)."""
     assert is_blank_text(None) is False
@@ -286,6 +330,48 @@ def test_repair_single_blank_does_not_fetch(cached_config, mocker):
     repairer.repair_single("", "PMID:TEST001")
 
     spy.assert_not_called()
+
+
+def test_blank_check_precedes_skip_references(cached_config):
+    """Skipping a reference silences repair for it, not for a defect in the data.
+
+    skip_references says "do not try to repair quotes against this reference".
+    A blank quote is not a judgement about the reference, so it is still
+    reported.
+    """
+    repair_config = RepairConfig(skip_references=["PMID:TEST001"])
+    repairer = SupportingTextRepairer(cached_config, repair_config)
+
+    result = repairer.repair_single("", "PMID:TEST001")
+
+    assert [a.action_type for a in result.actions] == [RepairActionType.REMOVAL]
+    assert "empty" in result.message.lower()
+
+
+def test_blank_check_precedes_trusted_low_similarity(cached_config):
+    """Trusting a reference suppresses REMOVAL for weak matches, not for blanks.
+
+    trusted_low_similarity exists so a poorly-matching quote is not proposed
+    for deletion. A blank excerpt has no match to judge, so the trust setting
+    does not apply and REMOVAL survives.
+    """
+    repair_config = RepairConfig(trusted_low_similarity=["PMID:TEST001"])
+    repairer = SupportingTextRepairer(cached_config, repair_config)
+
+    result = repairer.repair_single("", "PMID:TEST001")
+
+    assert [a.action_type for a in result.actions] == [RepairActionType.REMOVAL]
+
+
+def test_skip_references_still_honoured_for_real_text(cached_config):
+    """The precedence above must not break skip_references for ordinary quotes."""
+    repair_config = RepairConfig(skip_references=["PMID:TEST001"])
+    repairer = SupportingTextRepairer(cached_config, repair_config)
+
+    result = repairer.repair_single("fabricated quote", "PMID:TEST001")
+
+    assert result.actions == []
+    assert "skip" in result.message.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_empty_snippets.py
+++ b/tests/test_empty_snippets.py
@@ -9,7 +9,7 @@ Every layer must now treat a present-but-blank excerpt as an error:
 
 - ``SupportingTextValidator`` rejects blank text before it ever fetches
 - the LinkML plugin distinguishes an absent excerpt slot from a blank one
-- the repairer flags blank text for removal instead of attempting a fix
+- the repairer flags blank text for review instead of attempting a fix
 - the repair CLI collects blank snippets instead of silently dropping them
 """
 
@@ -152,13 +152,13 @@ def test_plugin_rejects_snippet_quoting_nothing(plugin, deep_context):
 
 
 def test_repair_single_flags_excerpt_quoting_nothing(cached_config):
-    """A bracket-only excerpt is flagged for removal, not repaired."""
+    """A bracket-only excerpt is flagged for review, not repaired."""
     repairer = SupportingTextRepairer(cached_config, RepairConfig())
 
     result = repairer.repair_single("[editorial note]", "PMID:TEST001")
 
     assert result.is_repaired is False
-    assert [a.action_type for a in result.actions] == [RepairActionType.EMPTY_EXCERPT]
+    assert [a.action_type for a in result.actions] == [RepairActionType.INSUFFICIENT_EXCERPT]
 
 
 def test_is_blank_text_non_string():
@@ -307,10 +307,10 @@ def test_plugin_valid_snippet_still_passes(plugin, deep_context):
 
 
 @pytest.mark.parametrize("text", ["", "  "])
-def test_repair_single_flags_blank_as_empty_excerpt(cached_config, text):
+def test_repair_single_flags_blank_as_insufficient(cached_config, text):
     """A blank snippet cannot be repaired; it is flagged for human review.
 
-    Reported as EMPTY_EXCERPT rather than REMOVAL: a removal recommendation
+    Reported as INSUFFICIENT_EXCERPT rather than REMOVAL: a removal recommendation
     means "this quote does not match the reference", a verdict reached by
     comparison. No comparison happens here, so borrowing that category would
     misreport how the conclusion was reached.
@@ -322,7 +322,7 @@ def test_repair_single_flags_blank_as_empty_excerpt(cached_config, text):
     assert result.was_valid is False
     assert result.is_repaired is False
     assert result.repaired_text is None
-    assert [a.action_type for a in result.actions] == [RepairActionType.EMPTY_EXCERPT]
+    assert [a.action_type for a in result.actions] == [RepairActionType.INSUFFICIENT_EXCERPT]
     assert result.actions[0].can_auto_fix is False
     assert "empty" in result.message.lower()
     assert result.path == "evidence[0].snippet"
@@ -339,14 +339,17 @@ def test_report_shows_empty_excerpt_distinctly(cached_config):
     report = repairer.repair_batch([("", "PMID:TEST001", "evidence[0].snippet")])
 
     output = repairer.format_report(report)
+    section = output.split("INSUFFICIENT EXCERPTS")[1].split("Summary:")[0]
 
-    assert "EMPTY" in output.upper()
-    assert "Similarity" not in output
-    assert "Snippet: '...'" not in output
-    assert "evidence[0].snippet" in output
+    assert "Excerpt: (empty)" in section
+    assert "evidence[0].snippet" in section
+    # Scoped to the section: a similarity score is meaningful for quotes that
+    # really were compared, so the assertion must not depend on the batch
+    # happening to contain none of those.
+    assert "Similarity" not in section
 
 
-def test_report_summary_counts_empty_excerpts(cached_config):
+def test_report_summary_counts_insufficient_excerpts(cached_config):
     """Giving empty excerpts their own section must not drop them from the tally."""
     repairer = SupportingTextRepairer(cached_config, RepairConfig())
     report = repairer.repair_batch(
@@ -357,9 +360,9 @@ def test_report_summary_counts_empty_excerpts(cached_config):
         ]
     )
 
-    assert report.empty_excerpt_count == 2
+    assert report.insufficient_excerpt_count == 2
     assert report.removal_count == 1
-    assert "Empty excerpts: 2" in repairer.format_report(report)
+    assert "Insufficient excerpts: 2" in repairer.format_report(report)
 
 
 def test_report_still_shows_fabricated_removals(cached_config):
@@ -408,7 +411,7 @@ def test_blank_check_precedes_skip_references(cached_config):
 
     result = repairer.repair_single("", "PMID:TEST001")
 
-    assert [a.action_type for a in result.actions] == [RepairActionType.EMPTY_EXCERPT]
+    assert [a.action_type for a in result.actions] == [RepairActionType.INSUFFICIENT_EXCERPT]
     assert "empty" in result.message.lower()
 
 
@@ -424,7 +427,7 @@ def test_blank_check_precedes_trusted_low_similarity(cached_config):
 
     result = repairer.repair_single("", "PMID:TEST001")
 
-    assert [a.action_type for a in result.actions] == [RepairActionType.EMPTY_EXCERPT]
+    assert [a.action_type for a in result.actions] == [RepairActionType.INSUFFICIENT_EXCERPT]
 
 
 def test_skip_references_still_honoured_for_real_text(cached_config):
@@ -626,5 +629,5 @@ def test_repair_single_flags_too_short_for_removal(cached_config):
     result = repairer.repair_single("the gene", "PMID:TEST001")
 
     assert result.is_repaired is False
-    assert [a.action_type for a in result.actions] == [RepairActionType.EMPTY_EXCERPT]
+    assert [a.action_type for a in result.actions] == [RepairActionType.INSUFFICIENT_EXCERPT]
     assert "too short" in result.message.lower()

--- a/tests/test_empty_snippets.py
+++ b/tests/test_empty_snippets.py
@@ -1,0 +1,332 @@
+"""Tests for rejection of substantively empty supporting text.
+
+An empty (or whitespace-only) snippet used to pass the whole validation stack
+vacuously: the empty string is a substring of every document, so every
+"is this quote in the reference?" check succeeded without any evidence being
+present. See https://github.com/monarch-initiative/dismech/issues/8550
+
+Every layer must now treat a present-but-blank excerpt as an error:
+
+- ``SupportingTextValidator`` rejects blank text before it ever fetches
+- the LinkML plugin distinguishes an absent excerpt slot from a blank one
+- the repairer flags blank text for removal instead of attempting a fix
+- the repair CLI collects blank snippets instead of silently dropping them
+"""
+
+from pathlib import Path
+
+import pytest
+from linkml.validator.validation_context import ValidationContext  # type: ignore[import-untyped]
+from linkml_runtime.utils.schemaview import SchemaView  # type: ignore[import-untyped]
+
+from linkml_reference_validator.cli.repair import _extract_evidence_items
+from linkml_reference_validator.models import (
+    ReferenceContent,
+    ReferenceValidationConfig,
+    RepairActionType,
+    RepairConfig,
+    ValidationSeverity,
+)
+from linkml_reference_validator.plugins.reference_validation_plugin import (
+    ReferenceValidationPlugin,
+)
+from linkml_reference_validator.validation.repairer import SupportingTextRepairer
+from linkml_reference_validator.validation.supporting_text_validator import (
+    SupportingTextValidator,
+    is_blank_text,
+)
+
+DATA_DIR = Path(__file__).parent / "data"
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+DEEP_SCHEMA = DATA_DIR / "test_schema_deep_nesting.yaml"
+
+BLANK_TEXTS = ["", " ", "   ", "\t", "\n", " \t\n ", " "]
+
+
+@pytest.fixture
+def config(tmp_path):
+    """Configuration pointing at an empty temporary cache."""
+    return ReferenceValidationConfig(
+        cache_dir=tmp_path / "cache",
+        rate_limit_delay=0.0,
+    )
+
+
+@pytest.fixture
+def validator(config):
+    """Validator under test."""
+    return SupportingTextValidator(config)
+
+
+@pytest.fixture
+def cached_config(tmp_path):
+    """Configuration with the test reference fixtures pre-cached."""
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    for fixture_file in FIXTURES_DIR.glob("*.md"):
+        (cache_dir / fixture_file.name).write_text(fixture_file.read_text())
+    for fixture_file in FIXTURES_DIR.glob("*.txt"):
+        (cache_dir / fixture_file.name).write_text(fixture_file.read_text())
+    return ReferenceValidationConfig(cache_dir=cache_dir, rate_limit_delay=0.0)
+
+
+@pytest.fixture
+def plugin(cached_config):
+    """Plugin with cached test references."""
+    return ReferenceValidationPlugin(config=cached_config)
+
+
+@pytest.fixture
+def deep_context(plugin):
+    """Validation context for the deeply nested test schema."""
+    schema_view = SchemaView(str(DEEP_SCHEMA))
+    context = ValidationContext(schema_view.schema, target_class="Community")
+    plugin.pre_process(context)
+    return context
+
+
+def _community(snippet_field: dict) -> dict:
+    """Build a Community instance whose single evidence item carries the given fields."""
+    return {
+        "name": "Test Community",
+        "members": [
+            {
+                "taxon_name": "Species A",
+                "evidence": [{"reference": "PMID:TEST001", **snippet_field}],
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# is_blank_text
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("text", BLANK_TEXTS)
+def test_is_blank_text_true(text):
+    """Empty and whitespace-only strings are blank."""
+    assert is_blank_text(text) is True
+
+
+@pytest.mark.parametrize("text", ["a", " a ", "[note]", "..."])
+def test_is_blank_text_false(text):
+    """Any string with a non-whitespace character is not blank."""
+    assert is_blank_text(text) is False
+
+
+def test_is_blank_text_non_string():
+    """Non-strings are not blank text (they are handled elsewhere)."""
+    assert is_blank_text(None) is False
+    assert is_blank_text(["a"]) is False
+
+
+# ---------------------------------------------------------------------------
+# SupportingTextValidator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("text", BLANK_TEXTS)
+def test_validate_rejects_blank_supporting_text(validator, text):
+    """A blank snippet is an error, not a vacuous pass."""
+    result = validator.validate(text, "PMID:TEST001")
+
+    assert result.is_valid is False
+    assert result.severity == ValidationSeverity.ERROR
+    assert "empty" in result.message.lower()
+
+
+def test_validate_blank_does_not_fetch(validator, mocker):
+    """A blank snippet fails without any reference lookup."""
+    spy = mocker.patch.object(validator.fetcher, "fetch")
+
+    result = validator.validate("", "PMID:TEST001")
+
+    assert result.is_valid is False
+    spy.assert_not_called()
+
+
+def test_validate_blank_rejected_for_skipped_prefix(tmp_path):
+    """Blank text is a data defect even when the reference prefix is skipped."""
+    config = ReferenceValidationConfig(
+        cache_dir=tmp_path / "cache",
+        rate_limit_delay=0.0,
+        skip_prefixes=["GO"],
+    )
+    validator = SupportingTextValidator(config)
+
+    result = validator.validate("", "GO:0008150")
+
+    assert result.is_valid is False
+    assert "empty" in result.message.lower()
+
+
+def test_find_text_in_reference_rejects_blank(validator):
+    """Blank text is not found, even though "" is a substring of everything."""
+    ref = ReferenceContent(
+        reference_id="PMID:123",
+        content="The protein functions in cell cycle regulation.",
+    )
+
+    match = validator.find_text_in_reference("", ref)
+
+    assert match.found is False
+    assert "empty" in match.error_message.lower()
+
+
+def test_find_text_in_reference_blank_without_content(validator):
+    """Blank text is reported as empty rather than as a missing-content problem."""
+    ref = ReferenceContent(reference_id="PMID:123", content=None)
+
+    match = validator.find_text_in_reference("   ", ref)
+
+    assert match.found is False
+    assert "empty" in match.error_message.lower()
+
+
+def test_validate_still_accepts_real_text(cached_config):
+    """The blank guard must not disturb ordinary validation."""
+    validator = SupportingTextValidator(cached_config)
+
+    result = validator.validate(
+        "Protein X functions in cell cycle regulation", "PMID:TEST001"
+    )
+
+    assert result.is_valid is True
+
+
+# ---------------------------------------------------------------------------
+# ReferenceValidationPlugin
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("text", ["", "   ", "\n"])
+def test_plugin_rejects_blank_snippet(plugin, deep_context, text):
+    """A present-but-blank snippet must produce a validation error."""
+    results = list(plugin.process(_community({"snippet": text}), deep_context))
+
+    assert len(results) == 1, (
+        "A blank snippet should be reported exactly once, "
+        f"got {[r.message for r in results]}"
+    )
+    assert "empty" in results[0].message.lower()
+    assert "snippet" in results[0].instantiates
+
+
+def test_plugin_blank_snippet_reported_without_reference(plugin, deep_context):
+    """A blank snippet is reported even when no reference is present to check it against."""
+    instance = {
+        "name": "Test Community",
+        "members": [{"taxon_name": "Species A", "evidence": [{"snippet": ""}]}],
+    }
+
+    results = list(plugin.process(instance, deep_context))
+
+    assert len(results) == 1
+    assert "empty" in results[0].message.lower()
+
+
+def test_plugin_absent_snippet_is_not_an_error(plugin, deep_context):
+    """An absent excerpt slot is LinkML's concern (required-ness), not ours."""
+    instance = _community({})
+
+    results = list(plugin.process(instance, deep_context))
+
+    assert results == []
+
+
+def test_plugin_null_snippet_is_not_an_error(plugin, deep_context):
+    """An explicitly null excerpt is absent, not blank."""
+    instance = _community({"snippet": None})
+
+    results = list(plugin.process(instance, deep_context))
+
+    assert results == []
+
+
+def test_plugin_valid_snippet_still_passes(plugin, deep_context):
+    """The blank guard must not flag genuine snippets."""
+    instance = _community(
+        {"snippet": "Protein X functions in cell cycle regulation"}
+    )
+
+    results = list(plugin.process(instance, deep_context))
+
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# SupportingTextRepairer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("text", ["", "  "])
+def test_repair_single_flags_blank_for_removal(cached_config, text):
+    """A blank snippet cannot be repaired; it is flagged for human review."""
+    repairer = SupportingTextRepairer(cached_config, RepairConfig())
+
+    result = repairer.repair_single(text, "PMID:TEST001", path="evidence[0].snippet")
+
+    assert result.was_valid is False
+    assert result.is_repaired is False
+    assert result.repaired_text is None
+    assert [a.action_type for a in result.actions] == [RepairActionType.REMOVAL]
+    assert result.actions[0].can_auto_fix is False
+    assert "empty" in result.message.lower()
+    assert result.path == "evidence[0].snippet"
+
+
+def test_repair_single_blank_does_not_fetch(cached_config, mocker):
+    """Repairing a blank snippet needs no reference lookup."""
+    repairer = SupportingTextRepairer(cached_config, RepairConfig())
+    spy = mocker.patch.object(repairer.fetcher, "fetch")
+
+    repairer.repair_single("", "PMID:TEST001")
+
+    spy.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Repair CLI extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_evidence_items_keeps_blank_snippet():
+    """Blank snippets must reach the repairer instead of being dropped."""
+    data = {
+        "evidence": [
+            {"reference": "PMID:TEST001", "snippet": ""},
+            {"reference": "PMID:TEST002", "snippet": "real text"},
+        ]
+    }
+
+    items = _extract_evidence_items(data, None, Path("unused.yaml"))
+
+    assert ("", "PMID:TEST001", "evidence[0]") in items
+    assert ("real text", "PMID:TEST002", "evidence[1]") in items
+
+
+def test_extract_evidence_items_prefers_non_blank_key():
+    """When both keys are present, a non-blank value still wins."""
+    data = {
+        "evidence": [
+            {
+                "reference": "PMID:TEST001",
+                "supporting_text": "",
+                "snippet": "real text",
+            }
+        ]
+    }
+
+    items = _extract_evidence_items(data, None, Path("unused.yaml"))
+
+    assert items == [("real text", "PMID:TEST001", "evidence[0]")]
+
+
+def test_extract_evidence_items_requires_reference():
+    """A blank snippet with no reference has nothing to repair against."""
+    data = {"evidence": [{"snippet": ""}]}
+
+    items = _extract_evidence_items(data, None, Path("unused.yaml"))
+
+    assert items == []

--- a/tests/test_empty_snippets.py
+++ b/tests/test_empty_snippets.py
@@ -158,7 +158,7 @@ def test_repair_single_flags_excerpt_quoting_nothing(cached_config):
     result = repairer.repair_single("[editorial note]", "PMID:TEST001")
 
     assert result.is_repaired is False
-    assert [a.action_type for a in result.actions] == [RepairActionType.REMOVAL]
+    assert [a.action_type for a in result.actions] == [RepairActionType.EMPTY_EXCERPT]
 
 
 def test_is_blank_text_non_string():
@@ -307,8 +307,14 @@ def test_plugin_valid_snippet_still_passes(plugin, deep_context):
 
 
 @pytest.mark.parametrize("text", ["", "  "])
-def test_repair_single_flags_blank_for_removal(cached_config, text):
-    """A blank snippet cannot be repaired; it is flagged for human review."""
+def test_repair_single_flags_blank_as_empty_excerpt(cached_config, text):
+    """A blank snippet cannot be repaired; it is flagged for human review.
+
+    Reported as EMPTY_EXCERPT rather than REMOVAL: a removal recommendation
+    means "this quote does not match the reference", a verdict reached by
+    comparison. No comparison happens here, so borrowing that category would
+    misreport how the conclusion was reached.
+    """
     repairer = SupportingTextRepairer(cached_config, RepairConfig())
 
     result = repairer.repair_single(text, "PMID:TEST001", path="evidence[0].snippet")
@@ -316,10 +322,68 @@ def test_repair_single_flags_blank_for_removal(cached_config, text):
     assert result.was_valid is False
     assert result.is_repaired is False
     assert result.repaired_text is None
-    assert [a.action_type for a in result.actions] == [RepairActionType.REMOVAL]
+    assert [a.action_type for a in result.actions] == [RepairActionType.EMPTY_EXCERPT]
     assert result.actions[0].can_auto_fix is False
     assert "empty" in result.message.lower()
     assert result.path == "evidence[0].snippet"
+
+
+def test_report_shows_empty_excerpt_distinctly(cached_config):
+    """The curator-facing report must say the excerpt is empty.
+
+    It previously rendered as "Similarity: 0%" over "Snippet: '...'", which
+    reads as an ellipsis-only quote that scored zero against the reference -
+    wrong on both counts, and indistinguishable from a fabricated quote.
+    """
+    repairer = SupportingTextRepairer(cached_config, RepairConfig())
+    report = repairer.repair_batch([("", "PMID:TEST001", "evidence[0].snippet")])
+
+    output = repairer.format_report(report)
+
+    assert "EMPTY" in output.upper()
+    assert "Similarity" not in output
+    assert "Snippet: '...'" not in output
+    assert "evidence[0].snippet" in output
+
+
+def test_report_summary_counts_empty_excerpts(cached_config):
+    """Giving empty excerpts their own section must not drop them from the tally."""
+    repairer = SupportingTextRepairer(cached_config, RepairConfig())
+    report = repairer.repair_batch(
+        [
+            ("", "PMID:TEST001", "e[0]"),
+            ("   ", "PMID:TEST002", "e[1]"),
+            ("a wholly fabricated sentence never written", "PMID:TEST001", "e[2]"),
+        ]
+    )
+
+    assert report.empty_excerpt_count == 2
+    assert report.removal_count == 1
+    assert "Empty excerpts: 2" in repairer.format_report(report)
+
+
+def test_report_still_shows_fabricated_removals(cached_config):
+    """The empty-excerpt section must not swallow ordinary removals."""
+    repairer = SupportingTextRepairer(cached_config, RepairConfig())
+    report = repairer.repair_batch(
+        [("wholly fabricated sentence never written", "PMID:TEST001", "e[0]")]
+    )
+
+    output = repairer.format_report(report)
+
+    assert "REMOVAL" in output.upper()
+    assert "not found in reference" in output
+
+
+def test_report_does_not_imply_truncation_of_short_text(cached_config):
+    """A quote shorter than the display limit must not be shown with an ellipsis."""
+    repairer = SupportingTextRepairer(cached_config, RepairConfig())
+    report = repairer.repair_batch([("a short fake quote", "PMID:TEST001", "e[0]")])
+
+    output = repairer.format_report(report)
+
+    assert "'a short fake quote'" in output
+    assert "a short fake quote...." not in output
 
 
 def test_repair_single_blank_does_not_fetch(cached_config, mocker):
@@ -344,7 +408,7 @@ def test_blank_check_precedes_skip_references(cached_config):
 
     result = repairer.repair_single("", "PMID:TEST001")
 
-    assert [a.action_type for a in result.actions] == [RepairActionType.REMOVAL]
+    assert [a.action_type for a in result.actions] == [RepairActionType.EMPTY_EXCERPT]
     assert "empty" in result.message.lower()
 
 
@@ -360,7 +424,7 @@ def test_blank_check_precedes_trusted_low_similarity(cached_config):
 
     result = repairer.repair_single("", "PMID:TEST001")
 
-    assert [a.action_type for a in result.actions] == [RepairActionType.REMOVAL]
+    assert [a.action_type for a in result.actions] == [RepairActionType.EMPTY_EXCERPT]
 
 
 def test_skip_references_still_honoured_for_real_text(cached_config):
@@ -562,5 +626,5 @@ def test_repair_single_flags_too_short_for_removal(cached_config):
     result = repairer.repair_single("the gene", "PMID:TEST001")
 
     assert result.is_repaired is False
-    assert [a.action_type for a in result.actions] == [RepairActionType.REMOVAL]
+    assert [a.action_type for a in result.actions] == [RepairActionType.EMPTY_EXCERPT]
     assert "too short" in result.message.lower()

--- a/tests/test_empty_snippets.py
+++ b/tests/test_empty_snippets.py
@@ -458,12 +458,18 @@ def test_extract_evidence_items_keeps_blank_snippet():
 
     items = _extract_evidence_items(data, None, Path("unused.yaml"))
 
-    assert ("", "PMID:TEST001", "evidence[0]") in items
-    assert ("real text", "PMID:TEST002", "evidence[1]") in items
+    assert ("", "PMID:TEST001", "evidence[0].snippet") in items
+    assert ("real text", "PMID:TEST002", "evidence[1].snippet") in items
 
 
-def test_extract_evidence_items_prefers_non_blank_key():
-    """When both keys are present, a non-blank value still wins."""
+def test_extract_evidence_items_reports_every_excerpt_key():
+    """Both keys are checked, matching the plugin.
+
+    Preferring one key meant an item carrying two excerpts had the second
+    silently unvalidated, while the LinkML plugin iterates every excerpt
+    field and checks each. A blank one alongside a real one is still a
+    defect and is still reported.
+    """
     data = {
         "evidence": [
             {
@@ -476,7 +482,10 @@ def test_extract_evidence_items_prefers_non_blank_key():
 
     items = _extract_evidence_items(data, None, Path("unused.yaml"))
 
-    assert items == [("real text", "PMID:TEST001", "evidence[0]")]
+    assert items == [
+        ("", "PMID:TEST001", "evidence[0].supporting_text"),
+        ("real text", "PMID:TEST001", "evidence[0].snippet"),
+    ]
 
 
 def test_extract_evidence_items_requires_reference():
@@ -648,7 +657,7 @@ def test_repair_writes_back_to_the_key_it_read_from():
     """
     from linkml_reference_validator.cli.repair import (
         _apply_repairs_to_data,
-        _excerpt_key,
+        _excerpt_keys,
     )
     from linkml_reference_validator.models import (
         RepairAction,
@@ -662,7 +671,7 @@ def test_repair_writes_back_to_the_key_it_read_from():
             {"reference": "PMID:TEST001", "supporting_text": "", "snippet": "CO2 levels"}
         ]
     }
-    assert _excerpt_key(data["evidence"][0]) == "snippet"
+    assert _excerpt_keys(data["evidence"][0]) == ["supporting_text", "snippet"]
 
     report = RepairReport()
     report.add_result(
@@ -672,7 +681,7 @@ def test_repair_writes_back_to_the_key_it_read_from():
             was_valid=False,
             is_repaired=True,
             repaired_text="CO₂ levels",
-            path="evidence[0]",
+            path="evidence[0].snippet",
             actions=[
                 RepairAction(
                     action_type=RepairActionType.CHARACTER_NORMALIZATION,
@@ -695,7 +704,7 @@ def test_repair_writes_back_to_supporting_text_when_it_holds_the_quote():
     """The ordinary case still writes to supporting_text."""
     from linkml_reference_validator.cli.repair import (
         _apply_repairs_to_data,
-        _excerpt_key,
+        _excerpt_keys,
     )
     from linkml_reference_validator.models import (
         RepairAction,
@@ -705,7 +714,7 @@ def test_repair_writes_back_to_supporting_text_when_it_holds_the_quote():
     )
 
     data = {"evidence": [{"reference": "PMID:TEST001", "supporting_text": "CO2 levels"}]}
-    assert _excerpt_key(data["evidence"][0]) == "supporting_text"
+    assert _excerpt_keys(data["evidence"][0]) == ["supporting_text"]
 
     report = RepairReport()
     report.add_result(
@@ -715,7 +724,7 @@ def test_repair_writes_back_to_supporting_text_when_it_holds_the_quote():
             was_valid=False,
             is_repaired=True,
             repaired_text="CO₂ levels",
-            path="evidence[0]",
+            path="evidence[0].supporting_text",
             actions=[
                 RepairAction(
                     action_type=RepairActionType.CHARACTER_NORMALIZATION,
@@ -730,3 +739,56 @@ def test_repair_writes_back_to_supporting_text_when_it_holds_the_quote():
     _apply_repairs_to_data(data, report, None)
 
     assert data["evidence"][0]["supporting_text"] == "CO₂ levels"
+
+
+def test_repair_writes_back_to_each_excerpt_key_independently():
+    """Two excerpts on one item repair into their own fields.
+
+    The path carries the key, so a fix for `snippet` cannot land in
+    `supporting_text` and vice versa.
+    """
+    from linkml_reference_validator.cli.repair import _apply_repairs_to_data
+    from linkml_reference_validator.models import (
+        RepairAction,
+        RepairConfidence,
+        RepairReport,
+        RepairResult,
+    )
+
+    data = {
+        "evidence": [
+            {
+                "reference": "PMID:TEST001",
+                "supporting_text": "CO2 levels",
+                "snippet": "H2O content",
+            }
+        ]
+    }
+
+    def _repaired(path, original, fixed):
+        return RepairResult(
+            reference_id="PMID:TEST001",
+            original_text=original,
+            was_valid=False,
+            is_repaired=True,
+            repaired_text=fixed,
+            path=path,
+            actions=[
+                RepairAction(
+                    action_type=RepairActionType.CHARACTER_NORMALIZATION,
+                    original_text=original,
+                    repaired_text=fixed,
+                    confidence=RepairConfidence.HIGH,
+                )
+            ],
+        )
+
+    report = RepairReport()
+    report.add_result(
+        _repaired("evidence[0].supporting_text", "CO2 levels", "CO₂ levels")
+    )
+    report.add_result(_repaired("evidence[0].snippet", "H2O content", "H₂O content"))
+
+    assert _apply_repairs_to_data(data, report, None) is True
+    assert data["evidence"][0]["supporting_text"] == "CO₂ levels"
+    assert data["evidence"][0]["snippet"] == "H₂O content"

--- a/tests/test_extractor_fidelity.py
+++ b/tests/test_extractor_fidelity.py
@@ -536,7 +536,10 @@ def test_extract_scope_matches_extract_for_a_plain_region():
     """The scope-taking entry point and the parsing one must agree."""
     from bs4 import BeautifulSoup
 
-    markup = "<div><p>Variants near (<i>GUSB</i>, <i>GRN</i>) were found.</p></div>"
+    markup = (
+        "<div><script>JUNKSCRIPT</script><style>JUNKSTYLE</style>"
+        "<p>Variants near (<i>GUSB</i>, <i>GRN</i>) were found.</p></div>"
+    )
     region = BeautifulSoup(markup, "html.parser").find("div")
 
     assert HTMLExtractor().extract_scope(region) == HTMLExtractor().extract(markup)
@@ -589,3 +592,42 @@ def test_extract_scope_drops_script_and_style():
     assert "JUNKSCRIPT" not in text
     assert "JUNKSTYLE" not in text
     assert "Variants near (GUSB, GRN) were found." in text
+
+
+def test_extract_scope_is_idempotent():
+    """Extraction must be repeatable on the same region.
+
+    The block fallback marks boundaries by inserting newlines; doing that in
+    the caller's tree meant a second call inserted a second separator after
+    every block, so the text grew on each pass.
+    """
+    from bs4 import BeautifulSoup
+
+    region = BeautifulSoup(
+        "<div class='b'><div>One</div><div>Two</div></div>", "html.parser"
+    ).find("div", class_="b")
+    extractor = HTMLExtractor()
+
+    first = extractor.extract_scope(region)
+
+    assert extractor.extract_scope(region) == first
+    assert extractor.extract_scope(region) == first
+
+
+def test_extract_scope_leaves_the_caller_tree_alone():
+    """A caller's parsed document must survive extraction unchanged.
+
+    extract_scope takes a tag the caller owns and still holds a reference to,
+    so stripping script/style and rewriting <br> in place would hand back a
+    document the caller never asked to have edited.
+    """
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(
+        "<div class='b'><script>JUNK</script><p>One<br>Two</p></div>", "html.parser"
+    )
+    before = str(soup)
+
+    HTMLExtractor().extract_scope(soup.find("div", class_="b"))
+
+    assert str(soup) == before

--- a/tests/test_extractor_fidelity.py
+++ b/tests/test_extractor_fidelity.py
@@ -410,3 +410,68 @@ def test_curated_snippet_in_restricted_mentioning_article_validates(validator):
     )
 
     assert match.found is True
+
+
+# ---------------------------------------------------------------------------
+# The PMC full-text provider: the other call site for the same XML
+#
+# ReferenceFetcher resolves full text through the provider registry, so this
+# path carries most PMC full text - more than PMIDSource._fetch_pmc_xml.
+# ---------------------------------------------------------------------------
+
+
+@patch("linkml_reference_validator.etl.fulltext.pmc.Entrez.efetch")
+def test_pmc_provider_preserves_accents_from_non_utf8_article(mock_efetch):
+    """The provider path must not re-encode either.
+
+    Re-encoding the str Entrez returns leaves an ISO-8859-1 declaration in
+    front of UTF-8 bytes, and the parser believes the declaration.
+    """
+    from linkml_reference_validator.etl.fulltext.pmc import PMCFullTextProvider
+
+    handle = MagicMock()
+    handle.read.return_value = (
+        '<?xml version="1.0" encoding="ISO-8859-1"?>'
+        "<article><body><sec><p>"
+        + LONG_BODY_FILLER
+        + "Fran\xe7ois measured 5 \xb5g."
+        + "</p></sec></body></article>"
+    )
+    mock_efetch.return_value = handle
+
+    text = PMCFullTextProvider()._fetch_pmc_xml_bytes(
+        "6358485", ReferenceValidationConfig(rate_limit_delay=0.0)
+    )
+    extracted = XMLExtractor().extract(text, content_type="application/xml")
+
+    assert extracted is not None
+    assert "François measured 5 µg." in extracted
+    assert "FranÃ§ois" not in extracted
+    assert "Âµ" not in extracted
+
+
+def test_pmc_provider_html_preserves_inline_markup():
+    """The provider's HTML fallback must get the shared extractor's fixes too.
+
+    It carried a private copy of the paragraph extraction, so it missed <br>
+    handling and anything else fixed in HTMLExtractor.
+    """
+    from linkml_reference_validator.etl.fulltext.pmc import PMCFullTextProvider
+
+    html = (
+        b"<html><body><div class='article-body'>"
+        b"<p>Variants near (<i>GUSB</i>, <i>GRN</i>) were found.</p>"
+        b"<p>Line one<br>Line two</p>"
+        b"</div></body></html>"
+    )
+
+    with patch(
+        "linkml_reference_validator.etl.fulltext.pmc.requests.get"
+    ) as mock_get:
+        mock_get.return_value = MagicMock(status_code=200, content=html)
+        text = PMCFullTextProvider()._fetch_pmc_html(
+            "123", ReferenceValidationConfig(rate_limit_delay=0.0)
+        )
+
+    assert "(GUSB, GRN)" in text
+    assert "Line oneLine two" not in text

--- a/tests/test_extractor_fidelity.py
+++ b/tests/test_extractor_fidelity.py
@@ -638,3 +638,28 @@ def test_extract_scope_leaves_the_caller_tree_alone():
     # Asserting only the former passes on a version that returns early.
     assert text == "One\nTwo"
     assert str(soup) == before
+
+
+@patch("linkml_reference_validator.etl.sources.pmid.Entrez.efetch")
+def test_pubmed_record_in_a_non_utf8_encoding_is_parsed(mock_efetch):
+    """PubMed metadata must survive a record that is not UTF-8.
+
+    _fetch_pubmed_xml decoded bytes as UTF-8 before parsing, so a record in
+    another encoding raised UnicodeDecodeError and took the abstract, MeSH
+    terms and publication types with it.
+    """
+    handle = MagicMock()
+    handle.read.return_value = (
+        '<?xml version="1.0" encoding="ISO-8859-1"?>'
+        "<PubmedArticle><Abstract>"
+        "<AbstractText>Fran\xe7ois measured the r\xe9sultats.</AbstractText>"
+        "</Abstract></PubmedArticle>"
+    ).encode("iso-8859-1")
+    mock_efetch.return_value = handle
+
+    soup = PMIDSource()._fetch_pubmed_xml(
+        "123", ReferenceValidationConfig(rate_limit_delay=0.0)
+    )
+
+    assert soup is not None
+    assert "François measured the résultats." in PMIDSource()._parse_abstract(soup)

--- a/tests/test_extractor_fidelity.py
+++ b/tests/test_extractor_fidelity.py
@@ -121,6 +121,10 @@ def test_restricted_in_reference_titles_does_not_discard_article():
         "The full text of this article cannot be obtained from PMC.",
         "This article is not available from PMC.",
         "Access to the full text is restricted by the publisher.",
+        # Wordings an exhaustive phrase list would miss; the length gate is
+        # what lets a broad "restricted" catch them safely.
+        "Access to this article is restricted.",
+        "Full text is restricted.",
     ],
 )
 def test_short_stub_notice_is_rejected(notice):
@@ -254,8 +258,59 @@ def test_html_paragraph_text_is_trimmed():
     assert text == "Indented sentence."
 
 
-def test_html_fallback_without_paragraphs_keeps_symbol_boundaries(validator):
-    """The no-<p> fallback must also keep gene symbols from fusing."""
+def test_html_fallback_without_paragraphs_keeps_symbol_boundaries():
+    """The no-<p> fallback must reproduce inline spacing exactly, like the <p> path.
+
+    Asserted on the extracted string rather than through the matcher: the
+    normalizer collapses whitespace and drops punctuation, so a matcher-based
+    assertion passes even on corrupted text like "(\\nGUSB\\n,\\nGRN\\n)" and
+    would not pin this behaviour at all.
+    """
+    html = (
+        b"<html><body><div>Variants near "
+        b"(<i>GUSB</i>, <i>GRN</i>, and <i>NEU1</i>) were found."
+        b"</div></body></html>"
+    )
+
+    text = HTMLExtractor().extract(html, content_type="text/html")
+
+    assert text == "Variants near (GUSB, GRN, and NEU1) were found."
+
+
+def test_html_fallback_separates_adjacent_block_elements():
+    """Preserving inline spacing must not let neighbouring blocks run together."""
+    html = b"<html><body><div>Introduction</div><div>The protein binds.</div></body></html>"
+
+    text = HTMLExtractor().extract(html, content_type="text/html")
+
+    assert "IntroductionThe" not in text
+    assert "Introduction" in text
+    assert "The protein binds." in text
+
+
+def test_html_fallback_separates_headings_and_list_items():
+    """Headings and list items are block boundaries too."""
+    html = b"<html><body><h1>Results</h1><ul><li>First</li><li>Second</li></ul></body></html>"
+
+    text = HTMLExtractor().extract(html, content_type="text/html")
+
+    assert "ResultsFirst" not in text
+    assert "FirstSecond" not in text
+
+
+def test_html_fallback_treats_br_as_a_break():
+    """A <br> is a line break, not a word boundary to be swallowed."""
+    html = b"<html><body><div>Line one<br>Line two</div></body></html>"
+
+    text = HTMLExtractor().extract(html, content_type="text/html")
+
+    assert "Line oneLine two" not in text
+    assert "Line one" in text
+    assert "Line two" in text
+
+
+def test_html_fallback_snippet_validates(validator):
+    """End to end on the fallback path, as on the paragraph path."""
     html = (
         b"<html><body><div>Variants near "
         b"(<i>GUSB</i>, <i>GRN</i>, and <i>NEU1</i>) were found."

--- a/tests/test_extractor_fidelity.py
+++ b/tests/test_extractor_fidelity.py
@@ -208,6 +208,33 @@ def test_pmc_xml_fetch_still_rejects_stub(mock_efetch):
 
 
 @patch("linkml_reference_validator.etl.sources.pmid.Entrez.efetch")
+def test_pmc_xml_fetch_preserves_accents_from_non_utf8_article(mock_efetch):
+    """Entrez hands back str; an ISO-8859-1 declaration must not corrupt it.
+
+    This is the production path. Re-encoding that str to UTF-8 leaves the
+    declaration saying ISO-8859-1, and the parser believes the declaration -
+    turning "François" into "FranÃ§ois" in author names and unit symbols.
+    """
+    handle = MagicMock()
+    handle.read.return_value = (
+        '<?xml version="1.0" encoding="ISO-8859-1"?>'
+        "<article><body><sec><p>"
+        + LONG_BODY_FILLER
+        + "Fran\xe7ois measured the r\xe9sultats."
+        + "</p></sec></body></article>"
+    )
+    mock_efetch.return_value = handle
+
+    text = PMIDSource()._fetch_pmc_xml(
+        "6358485", ReferenceValidationConfig(rate_limit_delay=0.0)
+    )
+
+    assert text is not None
+    assert "François measured the résultats." in text
+    assert "FranÃ§ois" not in text
+
+
+@patch("linkml_reference_validator.etl.sources.pmid.Entrez.efetch")
 def test_pmc_xml_fetch_accepts_bytes(mock_efetch):
     """Entrez may hand back bytes; extraction must cope either way."""
     handle = MagicMock()

--- a/tests/test_extractor_fidelity.py
+++ b/tests/test_extractor_fidelity.py
@@ -561,3 +561,31 @@ def test_extract_scope_handles_a_region_without_paragraphs():
     assert "Introduction" in text
     assert "The protein binds." in text
     assert "IntroductionThe" not in text
+
+
+def test_extract_scope_drops_script_and_style():
+    """Script and style content must never reach cached full text.
+
+    extract() decomposes them before selecting a region, but the three PMC
+    paths enter at extract_scope instead. bs4's get_text() happens to skip
+    Script/Stylesheet strings by default, so this held by luck of a library
+    default rather than by anything this code did - pinned here, and made
+    explicit in extract_scope, because a JSON-LD blob landing in a cached
+    article would silently corrupt every snippet check against it.
+    """
+    from bs4 import BeautifulSoup
+
+    region = BeautifulSoup(
+        "<div class='article-body'>"
+        '<script type="application/ld+json">{"headline":"JUNKSCRIPT"}</script>'
+        "<style>.hidden{content:'JUNKSTYLE'}</style>"
+        "<div>Variants near (<i>GUSB</i>, <i>GRN</i>) were found.</div>"
+        "</div>",
+        "html.parser",
+    ).find("div", class_="article-body")
+
+    text = HTMLExtractor().extract_scope(region)
+
+    assert "JUNKSCRIPT" not in text
+    assert "JUNKSTYLE" not in text
+    assert "Variants near (GUSB, GRN) were found." in text

--- a/tests/test_extractor_fidelity.py
+++ b/tests/test_extractor_fidelity.py
@@ -475,3 +475,27 @@ def test_pmc_provider_html_preserves_inline_markup():
 
     assert "(GUSB, GRN)" in text
     assert "Line oneLine two" not in text
+
+
+def test_pmid_source_html_fallback_preserves_inline_markup():
+    """PMIDSource's own HTML fallback carried the third copy of the same walk.
+
+    It never had the welding bug, but it got none of this PR's other HTML
+    work either - no <br> handling, no block-boundary fallback - and it is
+    live as the fallback in PMIDSource's full-text path.
+    """
+    html = (
+        b"<html><body><div class='article-body'>"
+        b"<p>Variants near (<i>GUSB</i>, <i>GRN</i>) were found.</p>"
+        b"<p>Line one<br>Line two</p>"
+        b"</div></body></html>"
+    )
+
+    with patch("linkml_reference_validator.etl.sources.pmid.requests.get") as mock_get:
+        mock_get.return_value = MagicMock(status_code=200, content=html)
+        text = PMIDSource()._fetch_pmc_html(
+            "123", ReferenceValidationConfig(rate_limit_delay=0.0)
+        )
+
+    assert "(GUSB, GRN)" in text
+    assert "Line oneLine two" not in text

--- a/tests/test_extractor_fidelity.py
+++ b/tests/test_extractor_fidelity.py
@@ -1,0 +1,303 @@
+"""Tests for content extraction fidelity.
+
+Two extractor bugs made the reference gate reject correctly curated snippets.
+See https://github.com/monarch-initiative/genesets/issues/10
+
+Bug 1 - over-aggressive stub detection: the XML extractor discarded any
+document containing the word "restricted" anywhere in its raw markup. Morris
+2019 (PMC6358485) is a 155 KB open-access paper whose Methods say the analysis
+was "restricted to ... high quality HRC imputed variants", so the whole article
+was thrown away and an 8.7 KB stub cached in its place, labelled as full text.
+
+Bug 2 - markup stripping corrupts text: the HTML extractor called
+``get_text(strip=True)`` with no separator, which strips each markup-delimited
+run *before* joining. Text around italicised gene symbols lost its spaces, so
+"(GUSB, GRN, and NEU1)" was extracted as "(GUSB,GRN, andNEU1)" and every
+snippet spanning an italicised gene symbol failed to match.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from linkml_reference_validator.etl.extract.html import HTMLExtractor
+from linkml_reference_validator.etl.extract.xml import (
+    MAX_STUB_NOTICE_CHARS,
+    XMLExtractor,
+    is_stub_notice,
+)
+from linkml_reference_validator.etl.sources.pmid import PMIDSource
+from linkml_reference_validator.models import (
+    ReferenceContent,
+    ReferenceValidationConfig,
+)
+from linkml_reference_validator.validation.supporting_text_validator import (
+    SupportingTextValidator,
+)
+
+# The sentence from Morris 2019 that used to discard the entire article.
+MORRIS_METHODS_SENTENCE = (
+    "The autosomal analysis was restricted to up to 13,977,204 high quality "
+    "HRC imputed variants."
+)
+
+# A paragraph long enough that no length-based stub gate could mistake it for
+# a placeholder, echoing a real article body.
+LONG_BODY_FILLER = (
+    "Bone mineral density was measured at the femoral neck and lumbar spine "
+    "in each participating cohort using dual-energy X-ray absorptiometry, "
+    "and association statistics were combined by fixed-effect meta-analysis "
+    "across all contributing studies before genomic control correction. "
+) * 6
+
+
+def _jats(*paragraphs: str) -> bytes:
+    """Build a minimal JATS article whose body holds the given paragraphs."""
+    body = "".join(f"<p>{p}</p>" for p in paragraphs)
+    return f"<article><body><sec>{body}</sec></body></article>".encode()
+
+
+@pytest.fixture
+def validator(tmp_path):
+    """Validator backed by an empty cache."""
+    return SupportingTextValidator(
+        ReferenceValidationConfig(cache_dir=tmp_path / "cache", rate_limit_delay=0.0)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: stub detection must not discard real articles
+# ---------------------------------------------------------------------------
+
+
+def test_long_article_mentioning_restricted_is_kept():
+    """The Morris 2019 regression: 'restricted' in Methods is not a stub marker."""
+    xml = _jats(LONG_BODY_FILLER, MORRIS_METHODS_SENTENCE)
+
+    text = XMLExtractor().extract(xml, content_type="application/xml")
+
+    assert text is not None, (
+        "A full article was discarded because its methods say 'restricted'"
+    )
+    assert MORRIS_METHODS_SENTENCE in text
+    assert LONG_BODY_FILLER.strip() in text
+
+
+def test_long_article_mentioning_cannot_be_obtained_is_kept():
+    """The other blanket phrase is equally capable of appearing in real prose."""
+    xml = _jats(
+        LONG_BODY_FILLER,
+        "Samples for which consent cannot be obtained were excluded from the analysis.",
+    )
+
+    text = XMLExtractor().extract(xml, content_type="application/xml")
+
+    assert text is not None
+    assert "consent cannot be obtained" in text
+
+
+def test_restricted_in_reference_titles_does_not_discard_article():
+    """The old check scanned raw markup, so even a cited title could kill an article."""
+    xml = (
+        "<article><body><sec><p>"
+        + LONG_BODY_FILLER
+        + "</p></sec></body>"
+        + "<back><ref-list><ref><article-title>"
+        + "Growth restricted infants and later disease"
+        + "</article-title></ref></ref-list></back></article>"
+    ).encode()
+
+    text = XMLExtractor().extract(xml, content_type="application/xml")
+
+    assert text is not None
+    assert LONG_BODY_FILLER.strip() in text
+
+
+@pytest.mark.parametrize(
+    "notice",
+    [
+        "The publisher of this article does not allow downloading of the full "
+        "text in XML form from PMC.",
+        "The full text of this article cannot be obtained from PMC.",
+        "This article is not available from PMC.",
+        "Access to the full text is restricted by the publisher.",
+    ],
+)
+def test_short_stub_notice_is_rejected(notice):
+    """Genuine PMC placeholder documents must still be discarded."""
+    assert XMLExtractor().extract(_jats(notice), content_type="application/xml") is None
+
+
+def test_is_stub_notice_requires_short_text():
+    """A stub is short by definition; length is what makes the phrases safe."""
+    notice = "The full text of this article cannot be obtained from PMC."
+
+    assert is_stub_notice(notice) is True
+    assert is_stub_notice(notice + " " + "x" * MAX_STUB_NOTICE_CHARS) is False
+
+
+def test_is_stub_notice_ignores_ordinary_short_text():
+    """Short text without a placeholder phrase is not a stub."""
+    assert is_stub_notice("A brief note about the assay.") is False
+
+
+def test_stub_detection_is_case_insensitive():
+    """PMC's wording casing must not decide the outcome."""
+    assert is_stub_notice("THIS ARTICLE IS NOT AVAILABLE FROM PMC.") is True
+
+
+# ---------------------------------------------------------------------------
+# Bug 1, second site: the PMID source had its own copy of the blanket check
+# ---------------------------------------------------------------------------
+
+
+@patch("linkml_reference_validator.etl.sources.pmid.Entrez.efetch")
+def test_pmc_xml_fetch_keeps_article_mentioning_restricted(mock_efetch):
+    """PMIDSource._fetch_pmc_xml duplicated the bug and must be fixed too."""
+    handle = MagicMock()
+    handle.read.return_value = _jats(
+        LONG_BODY_FILLER, MORRIS_METHODS_SENTENCE
+    ).decode()
+    mock_efetch.return_value = handle
+
+    text = PMIDSource()._fetch_pmc_xml(
+        "6358485", ReferenceValidationConfig(rate_limit_delay=0.0)
+    )
+
+    assert text is not None, (
+        "PMC XML fetch discarded a full article for saying 'restricted'"
+    )
+    assert MORRIS_METHODS_SENTENCE in text
+
+
+@patch("linkml_reference_validator.etl.sources.pmid.Entrez.efetch")
+def test_pmc_xml_fetch_still_rejects_stub(mock_efetch):
+    """A real placeholder response is still recognised as having no full text."""
+    handle = MagicMock()
+    handle.read.return_value = _jats(
+        "The publisher of this article does not allow downloading of the full "
+        "text in XML form from PMC."
+    ).decode()
+    mock_efetch.return_value = handle
+
+    text = PMIDSource()._fetch_pmc_xml(
+        "1234567", ReferenceValidationConfig(rate_limit_delay=0.0)
+    )
+
+    assert text is None
+
+
+@patch("linkml_reference_validator.etl.sources.pmid.Entrez.efetch")
+def test_pmc_xml_fetch_accepts_bytes(mock_efetch):
+    """Entrez may hand back bytes; extraction must cope either way."""
+    handle = MagicMock()
+    handle.read.return_value = _jats(LONG_BODY_FILLER)
+    mock_efetch.return_value = handle
+
+    text = PMIDSource()._fetch_pmc_xml(
+        "6358485", ReferenceValidationConfig(rate_limit_delay=0.0)
+    )
+
+    assert text is not None
+    assert LONG_BODY_FILLER.strip() in text
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: markup must not eat the whitespace around it
+# ---------------------------------------------------------------------------
+
+
+def test_html_preserves_spaces_around_italic_gene_symbols():
+    """The exact regression from the issue: italicised gene lists lost spaces."""
+    html = (
+        b"<html><body><p>Variants near three lysosomal genes "
+        b"(<i>GUSB</i>, <i>GRN</i>, and <i>NEU1</i>) reached significance."
+        b"</p></body></html>"
+    )
+
+    text = HTMLExtractor().extract(html, content_type="text/html")
+
+    assert "(GUSB, GRN, and NEU1)" in text
+    assert "andNEU1" not in text
+    assert "GUSB,GRN" not in text
+
+
+def test_html_preserves_spaces_across_other_inline_markup():
+    """Any inline markup, not just italics, must keep its surrounding spaces."""
+    html = (
+        b"<html><body><p>The <b>alpha</b> and <em>beta</em> subunits "
+        b"of <span>the complex</span> were purified.</p></body></html>"
+    )
+
+    text = HTMLExtractor().extract(html, content_type="text/html")
+
+    assert "The alpha and beta subunits of the complex were purified." in text
+
+
+def test_html_paragraphs_remain_separated():
+    """Fixing the intra-paragraph spacing must not fuse separate paragraphs."""
+    html = b"<html><body><p>First paragraph.</p><p>Second paragraph.</p></body></html>"
+
+    text = HTMLExtractor().extract(html, content_type="text/html")
+
+    assert "First paragraph." in text
+    assert "Second paragraph." in text
+    assert "First paragraph.Second" not in text
+
+
+def test_html_paragraph_text_is_trimmed():
+    """Source indentation around a paragraph should not survive extraction."""
+    html = b"<html><body><p>\n    Indented sentence.\n  </p></body></html>"
+
+    text = HTMLExtractor().extract(html, content_type="text/html")
+
+    assert text == "Indented sentence."
+
+
+def test_html_fallback_without_paragraphs_keeps_symbol_boundaries(validator):
+    """The no-<p> fallback must also keep gene symbols from fusing."""
+    html = (
+        b"<html><body><div>Variants near "
+        b"(<i>GUSB</i>, <i>GRN</i>, and <i>NEU1</i>) were found."
+        b"</div></body></html>"
+    )
+
+    text = HTMLExtractor().extract(html, content_type="text/html")
+
+    ref = ReferenceContent(reference_id="PMID:123", content=text)
+    assert validator.find_text_in_reference("(GUSB, GRN, and NEU1)", ref).found is True
+
+
+# ---------------------------------------------------------------------------
+# End to end: the curated snippet the gate used to reject now validates
+# ---------------------------------------------------------------------------
+
+
+def test_curated_snippet_spanning_italics_validates(validator):
+    """The user-visible outcome: a correct snippet is accepted, not rejected."""
+    html = (
+        b"<html><body><article><p>Three genes involved in lysosomal function "
+        b"(<i>GUSB</i>, <i>GRN</i>, and <i>NEU1</i>) were implicated by the "
+        b"Parkinson's disease GWAS.</p></article></body></html>"
+    )
+    content = HTMLExtractor().extract(html, content_type="text/html")
+    ref = ReferenceContent(reference_id="PMID:123", content=content)
+
+    match = validator.find_text_in_reference(
+        "Three genes involved in lysosomal function (GUSB, GRN, and NEU1)", ref
+    )
+
+    assert match.found is True
+
+
+def test_curated_snippet_in_restricted_mentioning_article_validates(validator):
+    """Both bugs together: a real article, kept, and matched on a real snippet."""
+    xml = _jats(LONG_BODY_FILLER, MORRIS_METHODS_SENTENCE)
+    content = XMLExtractor().extract(xml, content_type="application/xml")
+    ref = ReferenceContent(reference_id="PMID:30598549", content=content)
+
+    match = validator.find_text_in_reference(
+        "restricted to up to 13,977,204 high quality HRC imputed variants", ref
+    )
+
+    assert match.found is True

--- a/tests/test_extractor_fidelity.py
+++ b/tests/test_extractor_fidelity.py
@@ -439,7 +439,7 @@ def test_pmc_provider_preserves_accents_from_non_utf8_article(mock_efetch):
     )
     mock_efetch.return_value = handle
 
-    text = PMCFullTextProvider()._fetch_pmc_xml_bytes(
+    text = PMCFullTextProvider()._fetch_pmc_xml_source(
         "6358485", ReferenceValidationConfig(rate_limit_delay=0.0)
     )
     extracted = XMLExtractor().extract(text, content_type="application/xml")
@@ -453,8 +453,10 @@ def test_pmc_provider_preserves_accents_from_non_utf8_article(mock_efetch):
 def test_pmc_provider_html_preserves_inline_markup():
     """The provider's HTML fallback must get the shared extractor's fixes too.
 
-    It carried a private copy of the paragraph extraction, so it missed <br>
-    handling and anything else fixed in HTMLExtractor.
+    Pins <br> handling and inline-markup spacing on the paragraph branch; the
+    no-paragraph fallback is covered separately by
+    test_extract_scope_handles_a_region_without_paragraphs, since a fixture
+    with <p> elements never reaches it.
     """
     from linkml_reference_validator.etl.fulltext.pmc import PMCFullTextProvider
 
@@ -481,8 +483,9 @@ def test_pmid_source_html_fallback_preserves_inline_markup():
     """PMIDSource's own HTML fallback carried the third copy of the same walk.
 
     It never had the welding bug, but it got none of this PR's other HTML
-    work either - no <br> handling, no block-boundary fallback - and it is
-    live as the fallback in PMIDSource's full-text path.
+    work either, and it is live as the fallback in PMIDSource's full-text
+    path. Like its sibling, this pins <br> handling and inline spacing on the
+    paragraph branch, not the no-paragraph fallback.
     """
     html = (
         b"<html><body><div class='article-body'>"
@@ -499,3 +502,62 @@ def test_pmid_source_html_fallback_preserves_inline_markup():
 
     assert "(GUSB, GRN)" in text
     assert "Line oneLine two" not in text
+
+
+# ---------------------------------------------------------------------------
+# extract_scope: extracting from a region the caller already selected
+# ---------------------------------------------------------------------------
+
+
+def test_extract_scope_does_not_reselect_the_region():
+    """A caller-chosen region must be used whole, not narrowed again.
+
+    extract() picks <article>/<main> when given a whole document. Handing it a
+    region the caller already selected re-ran that choice inside the region, so
+    a nested <article> silently dropped everything around it.
+    """
+    from bs4 import BeautifulSoup
+
+    region = BeautifulSoup(
+        "<div class='article-body'>"
+        "<p>Introductory paragraph outside the nested element.</p>"
+        "<article><p>Nested article paragraph.</p></article>"
+        "</div>",
+        "html.parser",
+    ).find("div")
+
+    text = HTMLExtractor().extract_scope(region)
+
+    assert "Introductory paragraph outside the nested element." in text
+    assert "Nested article paragraph." in text
+
+
+def test_extract_scope_matches_extract_for_a_plain_region():
+    """The scope-taking entry point and the parsing one must agree."""
+    from bs4 import BeautifulSoup
+
+    markup = "<div><p>Variants near (<i>GUSB</i>, <i>GRN</i>) were found.</p></div>"
+    region = BeautifulSoup(markup, "html.parser").find("div")
+
+    assert HTMLExtractor().extract_scope(region) == HTMLExtractor().extract(markup)
+
+
+def test_extract_scope_handles_a_region_without_paragraphs():
+    """The block fallback runs for a region holding no <p> at all.
+
+    Both PMC HTML fallbacks returned None for such a region before delegating;
+    they now return its block-separated text. Recorded here because it changes
+    what counts as full text.
+    """
+    from bs4 import BeautifulSoup
+
+    region = BeautifulSoup(
+        "<div class='article-body'><div>Introduction</div><div>The protein binds.</div></div>",
+        "html.parser",
+    ).find("div", class_="article-body")
+
+    text = HTMLExtractor().extract_scope(region)
+
+    assert "Introduction" in text
+    assert "The protein binds." in text
+    assert "IntroductionThe" not in text

--- a/tests/test_extractor_fidelity.py
+++ b/tests/test_extractor_fidelity.py
@@ -113,6 +113,22 @@ def test_restricted_in_reference_titles_does_not_discard_article():
     assert LONG_BODY_FILLER.strip() in text
 
 
+def test_non_utf8_encoded_article_is_extracted():
+    """An article declaring a non-UTF-8 encoding must not blow up extraction."""
+    xml = (
+        '<?xml version="1.0" encoding="ISO-8859-1"?>'
+        "<article><body><sec><p>"
+        + LONG_BODY_FILLER
+        + "Fran\xe7ois measured the r\xe9sultats."
+        + "</p></sec></body></article>"
+    ).encode("iso-8859-1")
+
+    text = XMLExtractor().extract(xml, content_type="application/xml")
+
+    assert text is not None
+    assert "François" in text
+
+
 @pytest.mark.parametrize(
     "notice",
     [
@@ -301,6 +317,17 @@ def test_html_fallback_separates_headings_and_list_items():
 def test_html_fallback_treats_br_as_a_break():
     """A <br> is a line break, not a word boundary to be swallowed."""
     html = b"<html><body><div>Line one<br>Line two</div></body></html>"
+
+    text = HTMLExtractor().extract(html, content_type="text/html")
+
+    assert "Line oneLine two" not in text
+    assert "Line one" in text
+    assert "Line two" in text
+
+
+def test_html_paragraph_treats_br_as_a_break():
+    """The same on the paragraph path, which is the one users hit most."""
+    html = b"<html><body><p>Line one<br>Line two</p></body></html>"
 
     text = HTMLExtractor().extract(html, content_type="text/html")
 

--- a/tests/test_extractor_fidelity.py
+++ b/tests/test_extractor_fidelity.py
@@ -610,8 +610,12 @@ def test_extract_scope_is_idempotent():
 
     first = extractor.extract_scope(region)
 
-    assert extractor.extract_scope(region) == first
-    assert extractor.extract_scope(region) == first
+    # Anchored to the expected text, not merely to itself: comparing calls
+    # only to each other passes just as happily on three identical wrong
+    # answers as on three right ones.
+    assert first == "One\nTwo"
+    assert extractor.extract_scope(region) == "One\nTwo"
+    assert extractor.extract_scope(region) == "One\nTwo"
 
 
 def test_extract_scope_leaves_the_caller_tree_alone():
@@ -628,6 +632,9 @@ def test_extract_scope_leaves_the_caller_tree_alone():
     )
     before = str(soup)
 
-    HTMLExtractor().extract_scope(soup.find("div", class_="b"))
+    text = HTMLExtractor().extract_scope(soup.find("div", class_="b"))
 
+    # Both halves: the tree survives *and* extraction still works on the copy.
+    # Asserting only the former passes on a version that returns early.
+    assert text == "One\nTwo"
     assert str(soup) == before

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -102,3 +102,16 @@ def test_pdf_extractor_unknown_backend_raises():
 
     with pytest.raises(ValueError):
         PDFExtractor(backend="not-a-backend")
+
+
+def test_pdf_extractor_rejects_decoded_text():
+    """The base contract allows str, but a PDF is binary and cannot be one.
+
+    Extractor.extract accepts Union[bytes, str] so text sources can pass
+    already-decoded markup. PDF is the one format where that is meaningless,
+    so it says so plainly instead of failing inside the backend.
+    """
+    from linkml_reference_validator.etl.extract.pdf import PDFExtractor
+
+    with pytest.raises(TypeError):
+        PDFExtractor().extract("not really a pdf", content_type="application/pdf")

--- a/tests/test_fulltext_providers.py
+++ b/tests/test_fulltext_providers.py
@@ -166,7 +166,7 @@ class TestPMCProvider:
         xml = f"<article>{long_body}</article>".encode("utf-8")
 
         with patch.object(provider, "_resolve_pmcid", return_value="999"), \
-             patch.object(provider, "_fetch_pmc_xml_bytes", return_value=xml):
+             patch.object(provider, "_fetch_pmc_xml_source", return_value=xml):
             loc = provider.locate(ReferenceIdentifiers(pmid="123", pmcid="999"), config)
 
         assert loc is not None

--- a/tests/test_fulltext_providers.py
+++ b/tests/test_fulltext_providers.py
@@ -17,7 +17,12 @@ from linkml_reference_validator.etl.fulltext.base import (
 
 @pytest.fixture
 def config(tmp_path):
-    """Config for the module-level tests below (classes define their own)."""
+    """Config for the module-level tests and for TestPMCProvider.
+
+    TestUnpaywallProvider and TestOpenAlexProvider override it to add an
+    email; TestPMCProvider deliberately does not, so its tests and the
+    floor tests below share one definition.
+    """
     return ReferenceValidationConfig(cache_dir=tmp_path / "cache", rate_limit_delay=0.0)
 
 
@@ -322,3 +327,15 @@ def test_pmid_fulltext_accepts_a_body_past_the_floor(config):
 
     assert text == body
     assert content_type == "full_text_xml"
+
+
+def test_the_floor_does_not_follow_the_notice_length_down():
+    """The floor's absolute value, which every other test derives from.
+
+    xml.py asks a human to pin this to a literal before lowering
+    MAX_STUB_NOTICE_CHARS, because MIN_FULLTEXT_CHARS is derived from it.
+    Nothing else in the suite would notice if it moved: every fixture is
+    sized from the constant, so lowering it moves the tests with it and the
+    gates silently start admitting the band they just vacated.
+    """
+    assert MIN_FULLTEXT_CHARS >= 1000

--- a/tests/test_fulltext_providers.py
+++ b/tests/test_fulltext_providers.py
@@ -151,9 +151,9 @@ class TestOpenAlexProvider:
 
 
 class TestPMCProvider:
-    @pytest.fixture
-    def config(self, tmp_path):
-        return ReferenceValidationConfig(cache_dir=tmp_path / "cache", rate_limit_delay=0.0)
+    # Uses the module-level `config` fixture: the PMC floor tests below live
+    # outside this class, and a second identical fixture here would mean an
+    # edit to one of them never reaches the other.
 
     def test_name(self):
         from linkml_reference_validator.etl.fulltext.pmc import PMCFullTextProvider
@@ -233,23 +233,65 @@ def test_pmc_locate_rejects_html_below_the_floor(config):
     assert loc is None
 
 
-def test_pmc_locate_accepts_text_at_the_floor_boundary(config):
-    """One character past the floor is full text; the gate is exclusive."""
+def _pmc_xml_gate(config, text):
+    """Drive PMCFullTextProvider.locate's XML gate with body text of a given size."""
     from linkml_reference_validator.etl.fulltext.pmc import PMCFullTextProvider
 
     provider = PMCFullTextProvider()
+    xml = f"<article><body><p>{text}</p></body></article>".encode()
+    with patch.object(provider, "_resolve_pmcid", return_value="999"), \
+         patch.object(provider, "_fetch_pmc_xml_source", return_value=xml), \
+         patch.object(provider, "_fetch_pmc_html", return_value=None):
+        return provider.locate(ReferenceIdentifiers(pmcid="999"), config) is not None
 
+
+def _pmc_html_gate(config, text):
+    """Drive PMCFullTextProvider.locate's HTML fallback gate."""
+    from linkml_reference_validator.etl.fulltext.pmc import PMCFullTextProvider
+
+    provider = PMCFullTextProvider()
     with patch.object(provider, "_resolve_pmcid", return_value="999"), \
          patch.object(provider, "_fetch_pmc_xml_source", return_value=None), \
-         patch.object(provider, "_fetch_pmc_html", return_value="x" * MIN_FULLTEXT_CHARS):
-        assert provider.locate(ReferenceIdentifiers(pmcid="999"), config) is None
+         patch.object(provider, "_fetch_pmc_html", return_value=text):
+        return provider.locate(ReferenceIdentifiers(pmcid="999"), config) is not None
 
-    with patch.object(provider, "_resolve_pmcid", return_value="999"), \
-         patch.object(provider, "_fetch_pmc_xml_source", return_value=None), \
-         patch.object(
-             provider, "_fetch_pmc_html", return_value="x" * (MIN_FULLTEXT_CHARS + 1)
-         ):
-        assert provider.locate(ReferenceIdentifiers(pmcid="999"), config) is not None
+
+def _pmid_xml_gate(config, text):
+    """Drive PMIDSource._fetch_pmc_fulltext's XML gate."""
+    from linkml_reference_validator.etl.sources.pmid import PMIDSource
+
+    source = PMIDSource()
+    with patch.object(source, "_get_pmcid", return_value="999"), \
+         patch.object(source, "_fetch_pmc_xml", return_value=text), \
+         patch.object(source, "_fetch_pmc_html", return_value=None):
+        return source._fetch_pmc_fulltext("123", config)[0] is not None
+
+
+def _pmid_html_gate(config, text):
+    """Drive PMIDSource._fetch_pmc_fulltext's HTML fallback gate."""
+    from linkml_reference_validator.etl.sources.pmid import PMIDSource
+
+    source = PMIDSource()
+    with patch.object(source, "_get_pmcid", return_value="999"), \
+         patch.object(source, "_fetch_pmc_xml", return_value=None), \
+         patch.object(source, "_fetch_pmc_html", return_value=text):
+        return source._fetch_pmc_fulltext("123", config)[0] is not None
+
+
+@pytest.mark.parametrize(
+    "drive",
+    [_pmc_xml_gate, _pmc_html_gate, _pmid_xml_gate, _pmid_html_gate],
+    ids=["pmc-xml", "pmc-html", "pmid-xml", "pmid-html"],
+)
+def test_every_floor_gate_is_exclusive(config, drive):
+    """All four gates must agree that the floor itself is not enough.
+
+    Parametrized rather than written once: an earlier version pinned this on
+    the PMC HTML fallback alone, so the other three could each be changed
+    from > to >= with the suite still green.
+    """
+    assert drive(config, "x" * MIN_FULLTEXT_CHARS) is False
+    assert drive(config, "x" * (MIN_FULLTEXT_CHARS + 1)) is True
 
 
 def test_pmid_fulltext_rejects_responses_below_the_floor(config):

--- a/tests/test_fulltext_providers.py
+++ b/tests/test_fulltext_providers.py
@@ -3,7 +3,7 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
-from linkml_reference_validator.etl.extract.xml import MIN_FULLTEXT_CHARS
+from linkml_reference_validator.etl.extract import MIN_FULLTEXT_CHARS
 from linkml_reference_validator.models import (
     ReferenceValidationConfig,
     ReferenceIdentifiers,

--- a/tests/test_fulltext_providers.py
+++ b/tests/test_fulltext_providers.py
@@ -3,6 +3,7 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
+from linkml_reference_validator.etl.extract.xml import MIN_FULLTEXT_CHARS
 from linkml_reference_validator.models import (
     ReferenceValidationConfig,
     ReferenceIdentifiers,
@@ -12,6 +13,12 @@ from linkml_reference_validator.etl.fulltext.base import (
     FullTextProvider,
     FullTextProviderRegistry,
 )
+
+
+@pytest.fixture
+def config(tmp_path):
+    """Config for the module-level tests below (classes define their own)."""
+    return ReferenceValidationConfig(cache_dir=tmp_path / "cache", rate_limit_delay=0.0)
 
 
 class _FakeProvider(FullTextProvider):
@@ -162,8 +169,11 @@ class TestPMCProvider:
         from linkml_reference_validator.etl.fulltext.pmc import PMCFullTextProvider
 
         provider = PMCFullTextProvider()
-        long_body = "<body>" + "".join(f"<p>Sentence {i} of the body.</p>" for i in range(40)) + "</body>"
-        xml = f"<article>{long_body}</article>".encode("utf-8")
+        # Sized from the floor rather than from an incidental paragraph count:
+        # the previous fixture cleared MIN_FULLTEXT_CHARS by 28 characters, so
+        # shortening a sentence or raising the floor would have failed this
+        # test for a reason unrelated to what it checks.
+        xml = _pmc_article_xml(MIN_FULLTEXT_CHARS + 500)
 
         with patch.object(provider, "_resolve_pmcid", return_value="999"), \
              patch.object(provider, "_fetch_pmc_xml_source", return_value=xml):
@@ -172,4 +182,101 @@ class TestPMCProvider:
         assert loc is not None
         assert loc.format_hint == "xml"
         assert loc.provider == "pmc"
-        assert "Sentence 0 of the body." in loc.text
+        assert "Body sentence with enough prose" in loc.text
+        assert len(loc.text) > MIN_FULLTEXT_CHARS
+
+
+# ============================================================================
+# The full-text floor
+#
+# MIN_FULLTEXT_CHARS is the only stub defence on the HTML paths, and carries
+# the reasoning for both its own value and MAX_STUB_NOTICE_CHARS'. Nothing
+# asserted it: changing > to >= or deleting a gate left the suite green.
+# ============================================================================
+
+
+def _pmc_article_xml(length: int) -> bytes:
+    """Build PMC article XML whose extracted body text is at least `length`."""
+    filler = "Body sentence with enough prose to be worth counting. "
+    paragraphs = "".join(
+        f"<p>{filler * 4}</p>" for _ in range(length // (len(filler) * 4) + 1)
+    )
+    return f"<article><body>{paragraphs}</body></article>".encode()
+
+
+def test_pmc_locate_rejects_xml_below_the_floor(config):
+    """A body no longer than a placeholder notice is not full text."""
+    from linkml_reference_validator.etl.fulltext.pmc import PMCFullTextProvider
+
+    provider = PMCFullTextProvider()
+    short = b"<article><body><p>Too little to be an article body.</p></body></article>"
+
+    with patch.object(provider, "_resolve_pmcid", return_value="999"), \
+         patch.object(provider, "_fetch_pmc_xml_source", return_value=short), \
+         patch.object(provider, "_fetch_pmc_html", return_value=None):
+        loc = provider.locate(ReferenceIdentifiers(pmid="123", pmcid="999"), config)
+
+    assert loc is None
+
+
+def test_pmc_locate_rejects_html_below_the_floor(config):
+    """The HTML fallback is gated too - it has no is_stub_notice check at all."""
+    from linkml_reference_validator.etl.fulltext.pmc import PMCFullTextProvider
+
+    provider = PMCFullTextProvider()
+
+    with patch.object(provider, "_resolve_pmcid", return_value="999"), \
+         patch.object(provider, "_fetch_pmc_xml_source", return_value=None), \
+         patch.object(provider, "_fetch_pmc_html", return_value="Short landing page."):
+        loc = provider.locate(ReferenceIdentifiers(pmid="123", pmcid="999"), config)
+
+    assert loc is None
+
+
+def test_pmc_locate_accepts_text_at_the_floor_boundary(config):
+    """One character past the floor is full text; the gate is exclusive."""
+    from linkml_reference_validator.etl.fulltext.pmc import PMCFullTextProvider
+
+    provider = PMCFullTextProvider()
+
+    with patch.object(provider, "_resolve_pmcid", return_value="999"), \
+         patch.object(provider, "_fetch_pmc_xml_source", return_value=None), \
+         patch.object(provider, "_fetch_pmc_html", return_value="x" * MIN_FULLTEXT_CHARS):
+        assert provider.locate(ReferenceIdentifiers(pmcid="999"), config) is None
+
+    with patch.object(provider, "_resolve_pmcid", return_value="999"), \
+         patch.object(provider, "_fetch_pmc_xml_source", return_value=None), \
+         patch.object(
+             provider, "_fetch_pmc_html", return_value="x" * (MIN_FULLTEXT_CHARS + 1)
+         ):
+        assert provider.locate(ReferenceIdentifiers(pmcid="999"), config) is not None
+
+
+def test_pmid_fulltext_rejects_responses_below_the_floor(config):
+    """The PMID path has its own two gates on the same floor."""
+    from linkml_reference_validator.etl.sources.pmid import PMIDSource
+
+    source = PMIDSource()
+
+    with patch.object(source, "_get_pmcid", return_value="999"), \
+         patch.object(source, "_fetch_pmc_xml", return_value="Too short."), \
+         patch.object(source, "_fetch_pmc_html", return_value="Also too short."):
+        text, content_type = source._fetch_pmc_fulltext("123", config)
+
+    assert text is None
+    assert content_type == "pmc_restricted"
+
+
+def test_pmid_fulltext_accepts_a_body_past_the_floor(config):
+    """The rejection tests above must not pass by rejecting everything."""
+    from linkml_reference_validator.etl.sources.pmid import PMIDSource
+
+    source = PMIDSource()
+    body = "x" * (MIN_FULLTEXT_CHARS + 500)
+
+    with patch.object(source, "_get_pmcid", return_value="999"), \
+         patch.object(source, "_fetch_pmc_xml", return_value=body):
+        text, content_type = source._fetch_pmc_fulltext("123", config)
+
+    assert text == body
+    assert content_type == "full_text_xml"

--- a/tests/test_reference_fetcher.py
+++ b/tests/test_reference_fetcher.py
@@ -1,5 +1,7 @@
 """Tests for reference fetcher."""
 
+import logging
+
 import pytest
 from unittest.mock import patch, MagicMock
 from linkml_reference_validator.models import (
@@ -1266,6 +1268,28 @@ def _cached_text(fetcher, reference_id):
     return fetcher.get_cache_path(reference_id).read_text(encoding="utf-8")
 
 
+def _unstamp(fetcher, reference_id):
+    """Rewrite a cache entry as an older extractor would have left it."""
+    path = fetcher.get_cache_path(reference_id)
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            f"extractor_version: {EXTRACTOR_CACHE_VERSION}\n", ""
+        ),
+        encoding="utf-8",
+    )
+
+
+def _source_returning(mocker, content):
+    """Patch the registry so every reference resolves to a source yielding ``content``."""
+    return mocker.patch.object(
+        ReferenceSourceRegistry,
+        "get_source",
+        return_value=mocker.Mock(
+            return_value=mocker.Mock(fetch=mocker.Mock(return_value=content))
+        ),
+    )
+
+
 def test_saved_entry_carries_the_extractor_version(fetcher):
     """Every entry records which extraction it came from."""
     fetcher._save_to_disk(
@@ -1294,13 +1318,7 @@ def test_entry_without_a_version_is_not_served(fetcher):
     fetcher._save_to_disk(
         ReferenceContent(reference_id="PMID:1", content="Stale body text.")
     )
-    path = fetcher.get_cache_path("PMID:1")
-    path.write_text(
-        path.read_text(encoding="utf-8").replace(
-            f"extractor_version: {EXTRACTOR_CACHE_VERSION}\n", ""
-        ),
-        encoding="utf-8",
-    )
+    _unstamp(fetcher, "PMID:1")
 
     assert fetcher._load_from_disk("PMID:1") is None
 
@@ -1357,24 +1375,71 @@ def test_legacy_text_entry_is_still_served(fetcher):
     assert "legacy cache entry" in loaded.content
 
 
+def test_entry_whose_id_contains_a_horizontal_rule_is_not_perpetually_stale(fetcher):
+    """Frontmatter ends at a line that is ``---``, not at ``---`` inside a value.
+
+    A URL reference containing ``---`` would otherwise truncate the searched
+    block, hiding the stamp - so the entry would read as unstamped, be
+    re-fetched, be rewritten with the same id, and read as unstamped again on
+    every single run.
+    """
+    reference_id = "url:https://example.com/a---b"
+    fetcher._save_to_disk(
+        ReferenceContent(reference_id=reference_id, content="Body text.")
+    )
+
+    assert not fetcher._is_stale_cache_entry(_cached_text(fetcher, reference_id))
+
+    loaded = fetcher._load_from_disk(reference_id)
+    assert loaded is not None
+    assert loaded.reference_id == reference_id
+    assert loaded.content == "Body text."
+
+
+def test_horizontal_rule_in_a_title_does_not_truncate_the_frontmatter(fetcher):
+    """The same holds for any other value the source supplies."""
+    fetcher._save_to_disk(
+        ReferenceContent(
+            reference_id="PMID:1",
+            title="Before --- after",
+            content="Body text.",
+            journal="Nature",
+        )
+    )
+
+    loaded = fetcher._load_from_disk("PMID:1")
+
+    assert loaded is not None
+    assert loaded.journal == "Nature"
+
+
+def test_legacy_text_entry_is_exempt_even_if_it_starts_with_a_rule(fetcher):
+    """The exemption follows the file that was read, not what its text looks like.
+
+    A ``.txt`` entry whose first line happens to be ``---`` has no stamp to find,
+    so routing it by content rather than by which branch opened it would discard
+    it - the exact "someone's data for a problem they do not have" the exemption
+    exists to prevent.
+    """
+    legacy = fetcher.get_cache_path("PMID:1").with_suffix(".txt")
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_text("---\nBody text from a legacy cache entry.", encoding="utf-8")
+
+    loaded = fetcher._load_from_disk("PMID:1")
+
+    assert loaded is not None
+    assert "legacy cache entry" in loaded.content
+
+
 def test_stale_entry_is_refetched_and_restamped(fetcher, mocker):
     """A stale entry is replaced rather than merely ignored."""
     fetcher._save_to_disk(
         ReferenceContent(reference_id="PMID:1", content="Stale body text.")
     )
-    path = fetcher.get_cache_path("PMID:1")
-    path.write_text(
-        path.read_text(encoding="utf-8").replace(
-            f"extractor_version: {EXTRACTOR_CACHE_VERSION}\n", ""
-        ),
-        encoding="utf-8",
-    )
+    _unstamp(fetcher, "PMID:1")
 
-    fresh = ReferenceContent(reference_id="PMID:1", content="Freshly fetched text.")
-    mocker.patch.object(
-        ReferenceSourceRegistry, "get_source", return_value=mocker.Mock(
-            return_value=mocker.Mock(fetch=mocker.Mock(return_value=fresh))
-        )
+    _source_returning(
+        mocker, ReferenceContent(reference_id="PMID:1", content="Freshly fetched text.")
     )
 
     result = fetcher.fetch("PMID:1")
@@ -1384,6 +1449,94 @@ def test_stale_entry_is_refetched_and_restamped(fetcher, mocker):
     assert f"extractor_version: {EXTRACTOR_CACHE_VERSION}" in _cached_text(
         fetcher, "PMID:1"
     )
+
+
+# ---------------------------------------------------------------------------
+# Falling back to a stale entry when the source cannot be reached.
+#
+# Treating a stale entry as absent is only safe while the source can supply a
+# replacement. Offline, during an NCBI outage, or for a record since withdrawn,
+# "this text is out of date" must not become "this reference does not exist" -
+# otherwise the first offline run after upgrading reports every reference as
+# not found.
+# ---------------------------------------------------------------------------
+
+
+def test_stale_entry_is_served_when_the_source_cannot_be_reached(fetcher, mocker):
+    """An unreachable source falls back to the out-of-date copy on disk."""
+    fetcher._save_to_disk(
+        ReferenceContent(reference_id="PMID:1", content="Stale body text.")
+    )
+    _unstamp(fetcher, "PMID:1")
+
+    _source_returning(mocker, None)
+
+    result = fetcher.fetch("PMID:1")
+
+    assert result is not None
+    assert result.content == "Stale body text."
+
+
+def test_stale_fallback_warns_that_the_text_is_out_of_date(fetcher, mocker, caplog):
+    """Serving known-suspect text is a warning, not a silent success."""
+    fetcher._save_to_disk(
+        ReferenceContent(reference_id="PMID:1", content="Stale body text.")
+    )
+    _unstamp(fetcher, "PMID:1")
+    _source_returning(mocker, None)
+
+    with caplog.at_level(logging.WARNING):
+        fetcher.fetch("PMID:1")
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("PMID:1" in message for message in warnings)
+    assert any("older extractor" in message for message in warnings)
+
+
+def test_stale_fallback_is_not_written_back_to_disk(fetcher, mocker):
+    """The entry stays stale, so the next reachable run still refreshes it."""
+    fetcher._save_to_disk(
+        ReferenceContent(reference_id="PMID:1", content="Stale body text.")
+    )
+    _unstamp(fetcher, "PMID:1")
+    _source_returning(mocker, None)
+
+    fetcher.fetch("PMID:1")
+
+    assert "extractor_version:" not in _cached_text(fetcher, "PMID:1")
+
+
+def test_stale_entry_is_served_when_no_source_handles_the_id(fetcher, mocker):
+    """An unroutable ID is the same problem: the cached copy beats nothing."""
+    fetcher._save_to_disk(
+        ReferenceContent(reference_id="PMID:1", content="Stale body text.")
+    )
+    _unstamp(fetcher, "PMID:1")
+
+    mocker.patch.object(ReferenceSourceRegistry, "get_source", return_value=None)
+
+    result = fetcher.fetch("PMID:1")
+
+    assert result is not None
+    assert result.content == "Stale body text."
+
+
+def test_force_refresh_does_not_fall_back_to_the_stale_entry(fetcher, mocker):
+    """An explicit refresh that fails must report failure, not paper over it."""
+    fetcher._save_to_disk(
+        ReferenceContent(reference_id="PMID:1", content="Stale body text.")
+    )
+    _unstamp(fetcher, "PMID:1")
+    _source_returning(mocker, None)
+
+    assert fetcher.fetch("PMID:1", force_refresh=True) is None
+
+
+def test_missing_entry_still_returns_none_when_the_source_fails(fetcher, mocker):
+    """The fallback invents nothing: no cache entry means no result."""
+    _source_returning(mocker, None)
+
+    assert fetcher.fetch("PMID:1") is None
 
 
 def test_cache_export_still_reads_unstamped_entries(fetcher):
@@ -1396,12 +1549,6 @@ def test_cache_export_still_reads_unstamped_entries(fetcher):
     fetcher._save_to_disk(
         ReferenceContent(reference_id="PMID:1", title="Kept", content="Body.")
     )
-    path = fetcher.get_cache_path("PMID:1")
-    path.write_text(
-        path.read_text(encoding="utf-8").replace(
-            f"extractor_version: {EXTRACTOR_CACHE_VERSION}\n", ""
-        ),
-        encoding="utf-8",
-    )
+    _unstamp(fetcher, "PMID:1")
 
     assert [r.title for r in fetcher.iter_cached_references()] == ["Kept"]

--- a/tests/test_reference_fetcher.py
+++ b/tests/test_reference_fetcher.py
@@ -7,7 +7,11 @@ from linkml_reference_validator.models import (
     ReferenceContent,
     FullTextLocation,
 )
-from linkml_reference_validator.etl.reference_fetcher import ReferenceFetcher
+from linkml_reference_validator.etl.reference_fetcher import (
+    EXTRACTOR_CACHE_VERSION,
+    ReferenceFetcher,
+)
+from linkml_reference_validator.etl.sources.base import ReferenceSourceRegistry
 from linkml_reference_validator.etl.fulltext.base import (
     FullTextProvider,
     FullTextProviderRegistry,
@@ -1244,3 +1248,160 @@ def test_materialize_trusts_sniffed_format_over_hint(tmp_path):
     assert fmt == "html"
     assert pdf_bytes is None
     assert error is False
+
+
+# ============================================================================
+# Cache invalidation on extractor changes
+#
+# Fixing an extractor does not rewrite what it already cached. Entries written
+# before the stub-detection and markup-welding fixes hold text those bugs
+# produced - an 8.7 KB placeholder labelled as full text, or gene symbols
+# welded to their punctuation - and are served from disk forever, so correct
+# snippets keep being rejected with nothing in the output to explain why.
+# See https://github.com/monarch-initiative/genesets/issues/10
+# ============================================================================
+
+
+def _cached_text(fetcher, reference_id):
+    return fetcher.get_cache_path(reference_id).read_text(encoding="utf-8")
+
+
+def test_saved_entry_carries_the_extractor_version(fetcher):
+    """Every entry records which extraction it came from."""
+    fetcher._save_to_disk(
+        ReferenceContent(reference_id="PMID:1", content="Body text.")
+    )
+
+    assert f"extractor_version: {EXTRACTOR_CACHE_VERSION}" in _cached_text(
+        fetcher, "PMID:1"
+    )
+
+
+def test_entry_from_the_current_extractor_is_served(fetcher):
+    """The ordinary case: a current entry still comes back from disk."""
+    fetcher._save_to_disk(
+        ReferenceContent(reference_id="PMID:1", content="Body text.")
+    )
+
+    loaded = fetcher._load_from_disk("PMID:1")
+
+    assert loaded is not None
+    assert loaded.content == "Body text."
+
+
+def test_entry_without_a_version_is_not_served(fetcher):
+    """Entries written before the stamp existed are the poisoned ones."""
+    fetcher._save_to_disk(
+        ReferenceContent(reference_id="PMID:1", content="Stale body text.")
+    )
+    path = fetcher.get_cache_path("PMID:1")
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            f"extractor_version: {EXTRACTOR_CACHE_VERSION}\n", ""
+        ),
+        encoding="utf-8",
+    )
+
+    assert fetcher._load_from_disk("PMID:1") is None
+
+
+def test_entry_from_an_older_extractor_is_not_served(fetcher):
+    """A stamp older than the current one is equally stale."""
+    fetcher._save_to_disk(
+        ReferenceContent(reference_id="PMID:1", content="Stale body text.")
+    )
+    path = fetcher.get_cache_path("PMID:1")
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            f"extractor_version: {EXTRACTOR_CACHE_VERSION}",
+            f"extractor_version: {EXTRACTOR_CACHE_VERSION - 1}",
+        ),
+        encoding="utf-8",
+    )
+
+    assert fetcher._load_from_disk("PMID:1") is None
+
+
+def test_entry_from_a_newer_extractor_is_served(fetcher):
+    """A newer stamp is not stale - it just means an older tool is reading it."""
+    fetcher._save_to_disk(
+        ReferenceContent(reference_id="PMID:1", content="Body text.")
+    )
+    path = fetcher.get_cache_path("PMID:1")
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            f"extractor_version: {EXTRACTOR_CACHE_VERSION}",
+            f"extractor_version: {EXTRACTOR_CACHE_VERSION + 1}",
+        ),
+        encoding="utf-8",
+    )
+
+    assert fetcher._load_from_disk("PMID:1") is not None
+
+
+def test_legacy_text_entry_is_still_served(fetcher):
+    """The pre-Markdown format is deliberately exempt from the version check.
+
+    Nothing has written it for a long time, so such entries are as likely to
+    be hand-maintained as tool-written, and they are not what the extractor
+    bugs produced - those wrote Markdown. Invalidating them would discard
+    someone's data to fix a problem they do not have.
+    """
+    legacy = fetcher.get_cache_path("PMID:1").with_suffix(".txt")
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_text("Body text from a legacy cache entry.", encoding="utf-8")
+
+    loaded = fetcher._load_from_disk("PMID:1")
+
+    assert loaded is not None
+    assert "legacy cache entry" in loaded.content
+
+
+def test_stale_entry_is_refetched_and_restamped(fetcher, mocker):
+    """A stale entry is replaced rather than merely ignored."""
+    fetcher._save_to_disk(
+        ReferenceContent(reference_id="PMID:1", content="Stale body text.")
+    )
+    path = fetcher.get_cache_path("PMID:1")
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            f"extractor_version: {EXTRACTOR_CACHE_VERSION}\n", ""
+        ),
+        encoding="utf-8",
+    )
+
+    fresh = ReferenceContent(reference_id="PMID:1", content="Freshly fetched text.")
+    mocker.patch.object(
+        ReferenceSourceRegistry, "get_source", return_value=mocker.Mock(
+            return_value=mocker.Mock(fetch=mocker.Mock(return_value=fresh))
+        )
+    )
+
+    result = fetcher.fetch("PMID:1")
+
+    assert result is not None
+    assert result.content == "Freshly fetched text."
+    assert f"extractor_version: {EXTRACTOR_CACHE_VERSION}" in _cached_text(
+        fetcher, "PMID:1"
+    )
+
+
+def test_cache_export_still_reads_unstamped_entries(fetcher):
+    """Export and enrichment must not lose entries the validator re-fetches.
+
+    iter_cached_references is what `cache export` and the Zotero enrichment
+    walk; treating an unstamped entry as absent there would silently drop it
+    from an export rather than just re-fetching it for validation.
+    """
+    fetcher._save_to_disk(
+        ReferenceContent(reference_id="PMID:1", title="Kept", content="Body.")
+    )
+    path = fetcher.get_cache_path("PMID:1")
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            f"extractor_version: {EXTRACTOR_CACHE_VERSION}\n", ""
+        ),
+        encoding="utf-8",
+    )
+
+    assert [r.title for r in fetcher.iter_cached_references()] == ["Kept"]


### PR DESCRIPTION
## Summary

Three reported bugs, all in the same family: things that were substantively empty or corrupted passed or failed validation for the wrong reasons.

1. **Empty excerpts passed vacuously** ([dismech#8550](https://github.com/monarch-initiative/dismech/issues/8550)) — the empty string is a substring of every document, so a blank excerpt was recorded as verified evidence quoting nothing at all.
2. **Stub detection discarded real articles** ([genesets#10](https://github.com/monarch-initiative/genesets/issues/10)) — any document whose markup contained "restricted" was thrown away. Morris 2019 (PMC6358485) is a 155 KB open-access paper whose Methods restrict an analysis "to up to 13,977,204 high quality HRC imputed variants"; it was discarded and an 8.7 KB PMC placeholder cached as its full text.
3. **Markup stripping corrupted text** (genesets#10) — `get_text(strip=True)` trimmed each markup-delimited run before joining, so `(<i>GUSB</i>, <i>GRN</i>, and <i>NEU1</i>)` extracted as `(GUSB,GRN, andNEU1)`, breaking every snippet spanning an italicised gene symbol.

## ⚠️ Behaviour changes to expect on first run

These are the point of the PR, but they will surface immediately:

- **Blank excerpts now fail.** Data using `supporting_text: ""` or `snippet: ""` as a placeholder will report errors where it previously passed. An *absent* excerpt field is untouched — that stays your schema's business.
- **Blank excerpts outrank `skip_prefixes` and `trusted_low_similarity`.** A blank excerpt on a skipped or trusted reference changes from valid/INFO to ERROR. Those settings are statements about a *reference*; a blank excerpt is a defect in the data that no reference can excuse.
- **Cached references are re-fetched once.** Entries written before the extractor fixes hold content those bugs produced, so they are re-fetched the next time a validation needs them. The scope is the whole cache — every reference type, however it was populated — so a large pre-fetched cache re-fetches everything on first use, at `rate_limit_delay` per reference. Lazy and per-reference: nothing is deleted, and `cache export` / Zotero enrichment read older entries unchanged. If a reference can't be re-fetched (offline, outage, withdrawn record) the older copy is served with a warning rather than reported as missing. The explanation for the ordinary re-fetch is logged at INFO, so it needs `-v`. See [troubleshooting](docs/troubleshooting.md).
- **`repair data` exits non-zero** for a file whose only defect is an empty excerpt.
- **Repair report paths changed shape** — `evidence[0]` → `evidence[0].supporting_text`. That is what stops a repair landing in a different field than the quote came from, but anything downstream parsing those paths sees a different string.

## Key changes

### Empty excerpts

- `check_excerpt_content()` is the single source of truth for whether an excerpt has substance, used by the validator, the LinkML plugin and the repairer. It runs **before** any reference is fetched.
- Rejects blank text, and text that quotes nothing once editorial `[brackets]` and `...` separators are removed.
- `INSUFFICIENT_EXCERPT` is its own repair action with its own report section and exit-code contribution — deliberately *not* a `REMOVAL`, since a removal is a verdict reached by comparison and nothing here was compared.
- `min_excerpt_length` (opt-in, default `0`) rejects excerpts below a minimum, measured in **non-whitespace characters of quoted text** so PDF-to-text damage and chemical nomenclature don't distort it. Set it under `validation:` — top-level keys are silently ignored when a `validation:` section exists.
- `_substring_match` refuses an empty part list rather than returning `found=True`, keeping the primitive honest for new callers.

### Content extraction

- Stub detection runs on the *extracted body*, not raw markup, with a length gate — breadth in the phrase list is safe because a real article body can never be short enough to match.
- Whitespace around inline markup is preserved; `<br>` becomes a newline on every path.
- All three PMC paths share one HTML text extractor via `extract_scope()`, which takes an already-parsed region without re-parsing or re-scoping it, and does not modify the caller's tree.
- XML is passed to the parser as received — decoding or re-encoding it corrupts articles that declare a non-UTF-8 encoding (`François` → `FranÃ§ois`).
- One `MIN_FULLTEXT_CHARS` floor for all four full-text gates.
- The extractor modules point at `EXTRACTOR_CACHE_VERSION`, so the next extraction fix is made next to a note about the cache it invalidates.

### Caching

- Entries record `extractor_version`; the validation read path treats older stamps as absent so they refresh. Newer stamps are left alone, so two versions sharing one cache don't re-fetch each other's work.
- A stale entry is served, with a warning, when the source yields nothing — and left unrewritten, so the next reachable run still refreshes it. `--force` opts out.
- Frontmatter ends at a line that is exactly `---`. Splitting on the bare string let a value containing `---` (a URL reference id, a title) truncate the block: it hid the version stamp, making such entries re-fetch on every run, and dropped every field after it on load.

## Testing

799 tests, 200 doctests, mypy and ruff clean. Regression tests name the exact cases from the reports — the Morris 2019 sentence, the `(GUSB, GRN, and NEU1)` gene list — and assert the previously-rejected snippets now validate end to end.

The full-text floor, the empty-excerpt exit code and the offline fallback are verified by mutating the source and confirming the intended tests fail, rather than by writing tests and watching them pass.

## Smaller behaviour notes

- `repair data` now checks *every* excerpt key on an item, matching the plugin. An item carrying the same quote under both `supporting_text` and `snippet` is therefore reported once per key; the reference itself is fetched once.
- A non-string `supporting_text` (a list, say) is dropped by the repair CLI rather than throwing inside `_split_query`.

https://claude.ai/code/session_018ePtLQDGiymEgrfJKKPrLs